### PR TITLE
add consume until offset flag

### DIFF
--- a/commands/consume/command.go
+++ b/commands/consume/command.go
@@ -30,6 +30,7 @@ func (c *consumption) command() *cobra.Command {
 	cmd.Flags().DurationVar(&c.fetchMaxWait, "fetch-max-wait", 5*time.Second, "maximum amount of time to wait when fetching from a broker before the broker replies")
 	cmd.Flags().StringVar(&c.rack, "rack", "", "the rack to use for fetch requests; setting this opts in to nearest replica fetching (Kafka 2.2.0+)")
 	cmd.Flags().BoolVar(&c.readUncommitted, "read-uncommitted", false, "opt in to reading uncommitted offsets")
+	cmd.Flags().Int32Var(&c.untilOffset, "until-offset", -1, "consume each partition up to the latest stable offset, decremented by this value.")
 	return cmd
 }
 
@@ -155,4 +156,9 @@ Combined with producing, these two commands allow you to easily mirror a topic.
 
 If you do not like %, you can switch the escape character with a flag.
 Unfortunately, with exact sizing, the format string is unavoidably noisy.
+
+The --until-offset flag allows kcl to terminate consumption after reaching some
+offset, in relation to the latest stable offsets. For example, if the LSO of
+the topic partition is 25 and --until-offset=2 the topic partition will be
+consumed through offset 23.
 `

--- a/commands/consume/command.go
+++ b/commands/consume/command.go
@@ -20,7 +20,7 @@ func (c *consumption) command() *cobra.Command {
 	cmd.Flags().StringVarP(&c.groupAlg, "balancer", "b", "cooperative-sticky", "group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky)")
 	cmd.Flags().StringVarP(&c.instanceID, "instance-id", "i", "", "group instance ID to use for consuming; empty means none (implies static membership, Kafka 2.3.0+)")
 	cmd.Flags().Int32SliceVarP(&c.partitions, "partitions", "p", nil, "comma delimited list of specific partitions to consume")
-	cmd.Flags().StringVarP(&c.offset, "offset", "o", "start", "offset to start consuming from (start, end, 47, start+2, end-3)")
+	cmd.Flags().StringVarP(&c.offset, "offset", "o", "start", "offset to start consuming from (start, end, 47, start+2, end-3), or offset to consume until (:end-2, :end+4)")
 	cmd.Flags().IntVarP(&c.num, "num", "n", 0, "quit after consuming this number of records; 0 is unbounded")
 	cmd.Flags().IntVar(&c.numPerPartition, "num-per-partition", 0, "stop printing individual partitions after this many records; 0 is unbounded")
 	cmd.Flags().StringVarP(&c.format, "format", "f", `%v\n`, "output format")
@@ -30,7 +30,6 @@ func (c *consumption) command() *cobra.Command {
 	cmd.Flags().DurationVar(&c.fetchMaxWait, "fetch-max-wait", 5*time.Second, "maximum amount of time to wait when fetching from a broker before the broker replies")
 	cmd.Flags().StringVar(&c.rack, "rack", "", "the rack to use for fetch requests; setting this opts in to nearest replica fetching (Kafka 2.2.0+)")
 	cmd.Flags().BoolVar(&c.readUncommitted, "read-uncommitted", false, "opt in to reading uncommitted offsets")
-	cmd.Flags().Int32Var(&c.untilOffset, "until-offset", -1, "consume each partition up to the latest stable offset, decremented by this value.")
 	return cmd
 }
 
@@ -156,9 +155,4 @@ Combined with producing, these two commands allow you to easily mirror a topic.
 
 If you do not like %, you can switch the escape character with a flag.
 Unfortunately, with exact sizing, the format string is unavoidably noisy.
-
-The --until-offset flag allows kcl to terminate consumption after reaching some
-offset, in relation to the latest stable offsets. For example, if the LSO of
-the topic partition is 25 and --until-offset=2 the topic partition will be
-consumed through offset 23.
 `

--- a/commands/consume/command.go
+++ b/commands/consume/command.go
@@ -20,7 +20,7 @@ func (c *consumption) command() *cobra.Command {
 	cmd.Flags().StringVarP(&c.groupAlg, "balancer", "b", "cooperative-sticky", "group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky)")
 	cmd.Flags().StringVarP(&c.instanceID, "instance-id", "i", "", "group instance ID to use for consuming; empty means none (implies static membership, Kafka 2.3.0+)")
 	cmd.Flags().Int32SliceVarP(&c.partitions, "partitions", "p", nil, "comma delimited list of specific partitions to consume")
-	cmd.Flags().StringVarP(&c.offset, "offset", "o", "start", "offset to start consuming from (start, end, 47, start+2, end-3), or offset to consume until (:end-2, :end+4)")
+	cmd.Flags().StringVarP(&c.offset, "offset", "o", "start", "offset to start consuming from (start, end, 47, start+2, end-3) or to (:end-2, :end+4)")
 	cmd.Flags().IntVarP(&c.num, "num", "n", 0, "quit after consuming this number of records; 0 is unbounded")
 	cmd.Flags().IntVar(&c.numPerPartition, "num-per-partition", 0, "stop printing individual partitions after this many records; 0 is unbounded")
 	cmd.Flags().StringVarP(&c.format, "format", "f", `%v\n`, "output format")

--- a/commands/consume/consume.go
+++ b/commands/consume/consume.go
@@ -176,6 +176,32 @@ func (c *consumption) run(topics []string) {
 			}
 		}
 
+		startOffsets, err := adm.ListStartOffsets(ctx, topics...)
+
+		for t, ps := range startOffsets {
+			for p := range ps {
+				if lsoPartition, ok := offsets[t]; ok {
+					if lsoOffset, ok := lsoPartition[p]; ok {
+						if ps[p].Offset == lsoOffset.Offset {
+							delete(offsets[t], p)
+						}
+					}
+				}
+			}
+		}
+
+		empty := true
+		for _, ps := range offsets {
+			if len(ps) > 0 {
+				empty = false
+				break
+			}
+		}
+
+		if empty {
+			os.Exit(0)
+		}
+
 		co.untilOffset = true
 		for t, ps := range offsets {
 			for p, o := range ps {

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.15
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/aws/aws-sdk-go v1.40.55
-	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/twmb/franz-go v1.2.3
+	github.com/twmb/franz-go/pkg/kadm v0.0.0-20220331035613-01d0c45d69d2
 	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7
 	github.com/twmb/go-strftime v0.0.0-20190915101236-e74f7c4fe4fa
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,11 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/twmb/franz-go v1.2.3-0.20211104052441-7952375c09c0/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
 github.com/twmb/franz-go v1.2.3 h1:K4Zommxo0qZuNnKEt4CcunHPLKdqDCUhcwoU+YdvQjo=
 github.com/twmb/franz-go v1.2.3/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20220331035613-01d0c45d69d2 h1:itAdsd6dgsUXU3TcGTecE/2g59gRMqZNSlCJ9umE/HE=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20220331035613-01d0c45d69d2/go.mod h1:fuA2THFeFx/ms1w1R432uxWJqq7o3Q+olvJR4NFpWcM=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7 h1:YW4mW39H53O1qouKQnlrdNwyqAi5c4P10Oig8yndDKQ=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/go-rbtree v1.0.0 h1:KxN7dXJ8XaZ4cvmHV1qqXTshxX3EBvX/toG5+UR49Mg=


### PR DESCRIPTION
Hi @twmb - I've added some support for a consume until flag `--until-offset`, this addresses one of the features I requested in https://github.com/twmb/kcl/issues/11. I've implemented this as an offset from the LSO, because depending on the distribution (redpanda, apache, etc.) and whether the topics are transactional or not, it may not be desirable to consume all the way to the LSO and some offset from it is needed. In the case of transactional topics, the message at the LSO isn't exposed to the client, so on an idle partition, it wouldn't work to use that as an exit marker. Not sure if that's the best way to go about it, but this does seem to work the way I expect.

Let me know what you think. 