### PR TITLE
add tombstone producer flag

### DIFF
--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -24,6 +24,7 @@ func Command(cl *client.Client) *cobra.Command {
 		escapeChar    string
 		acks          int
 		retries       int
+		tombstone     bool
 	)
 
 	cmd := &cobra.Command{
@@ -145,7 +146,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 				out.Die("invalid multi character escape character")
 			}
 
-			reader, err := format.NewReader(informat, escape, maxBuf, os.Stdin)
+			reader, err := format.NewReader(informat, escape, maxBuf, os.Stdin, tombstone)
 			out.MaybeDie(err, "unable to parse in format: %v", err)
 			if reader.ParsesTopic() && len(args) == 1 {
 				out.Die("cannot produce to a specific topic; the parse format specifies that it parses a topic")
@@ -227,6 +228,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 	cmd.Flags().StringVarP(&escapeChar, "escape-char", "c", "%", "character to use for beginning a record field escape (accepts any utf8, for both format and verbose-format)")
 	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required, -1 is all in sync replicas, 1 is leader replica only, 0 is no acks required (0 disables idempotency)")
 	cmd.Flags().IntVar(&retries, "retries", -1, "number of times to retry producing if non-negative")
+	cmd.Flags().BoolVar(&tombstone, "tombstone", false, "produce emtpy values as tombstones")
 
 	return cmd
 }

--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -228,7 +228,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 	cmd.Flags().StringVarP(&escapeChar, "escape-char", "c", "%", "character to use for beginning a record field escape (accepts any utf8, for both format and verbose-format)")
 	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required, -1 is all in sync replicas, 1 is leader replica only, 0 is no acks required (0 disables idempotency)")
 	cmd.Flags().IntVar(&retries, "retries", -1, "number of times to retry producing if non-negative")
-	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce emtpy values as tombstones")
+	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce empty values as tombstones")
 
 	return cmd
 }

--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -228,7 +228,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 	cmd.Flags().StringVarP(&escapeChar, "escape-char", "c", "%", "character to use for beginning a record field escape (accepts any utf8, for both format and verbose-format)")
 	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required, -1 is all in sync replicas, 1 is leader replica only, 0 is no acks required (0 disables idempotency)")
 	cmd.Flags().IntVar(&retries, "retries", -1, "number of times to retry producing if non-negative")
-	cmd.Flags().BoolVar(&tombstone, "tombstone", false, "produce emtpy values as tombstones")
+	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce emtpy values as tombstones")
 
 	return cmd
 }

--- a/commands/transact/transact.go
+++ b/commands/transact/transact.go
@@ -62,6 +62,7 @@ func Command(cl *client.Client) *cobra.Command {
 		compression string
 		txnID       string
 		verbose     bool
+		tombstone   bool
 	)
 
 	cmd := &cobra.Command{
@@ -178,7 +179,7 @@ func Command(cl *client.Client) *cobra.Command {
 			w, err := format.ParseWriteFormat(writeFormat, escape)
 			out.MaybeDie(err, "unable to parse write format: %v", err)
 
-			r, err := format.NewReader(readFormat, escape, maxBuf, nil)
+			r, err := format.NewReader(readFormat, escape, maxBuf, nil, tombstone)
 			out.MaybeDie(err, "unable to parse read format: %v", err)
 			if r.ParsesTopic() && len(destTopic) != 0 {
 				out.Die("cannot produce to a destination topic; the read format specifies that it parses a topic")
@@ -209,6 +210,7 @@ func Command(cl *client.Client) *cobra.Command {
 	cmd.Flags().StringVarP(&destTopic, "destination-topic", "d", "", "if non-empty, the topic to produce to (read-format must not contain %t)")
 	cmd.Flags().StringVarP(&txnID, "txn-id", "x", "", "transactional ID")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose printing of transactions")
+	cmd.Flags().BoolVar(&tombstone, "tombstone", false, "produce emtpy values as tombstones")
 
 	return cmd
 }

--- a/commands/transact/transact.go
+++ b/commands/transact/transact.go
@@ -210,7 +210,7 @@ func Command(cl *client.Client) *cobra.Command {
 	cmd.Flags().StringVarP(&destTopic, "destination-topic", "d", "", "if non-empty, the topic to produce to (read-format must not contain %t)")
 	cmd.Flags().StringVarP(&txnID, "txn-id", "x", "", "transactional ID")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose printing of transactions")
-	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce emtpy values as tombstones")
+	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce empty values as tombstones")
 
 	return cmd
 }

--- a/commands/transact/transact.go
+++ b/commands/transact/transact.go
@@ -210,7 +210,7 @@ func Command(cl *client.Client) *cobra.Command {
 	cmd.Flags().StringVarP(&destTopic, "destination-topic", "d", "", "if non-empty, the topic to produce to (read-format must not contain %t)")
 	cmd.Flags().StringVarP(&txnID, "txn-id", "x", "", "transactional ID")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose printing of transactions")
-	cmd.Flags().BoolVar(&tombstone, "tombstone", false, "produce emtpy values as tombstones")
+	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce emtpy values as tombstones")
 
 	return cmd
 }


### PR DESCRIPTION
Hi @twmb this addresses the other feature request from https://github.com/twmb/kcl/issues/11. It adds a flag to the producer to produce tombstones when a value is empty.