### PR TITLE
Specify partition on produce

### DIFF
--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -25,6 +25,7 @@ func Command(cl *client.Client) *cobra.Command {
 		acks          int
 		retries       int
 		tombstone     bool
+		partition     int
 	)
 
 	cmd := &cobra.Command{
@@ -192,6 +193,10 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 				out.Die("invalid acks %d not in allowed -1, 0, 1", acks)
 			}
 
+			if partition > -1 {
+				cl.AddOpt(kgo.RecordPartitioner(kgo.ManualPartitioner()))
+			}
+
 			if retries > -1 {
 				cl.AddOpt(kgo.RecordRetries(retries))
 			}
@@ -208,6 +213,11 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 				if !reader.ParsesTopic() {
 					r.Topic = args[0]
 				}
+
+				if partition > -1 {
+					r.Partition = int32(partition)
+				}
+
 				cl.Client().Produce(context.Background(), r, func(r *kgo.Record, err error) {
 					out.MaybeDie(err, "unable to produce record: %v", err)
 					if verboseFn != nil {
@@ -229,6 +239,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required, -1 is all in sync replicas, 1 is leader replica only, 0 is no acks required (0 disables idempotency)")
 	cmd.Flags().IntVar(&retries, "retries", -1, "number of times to retry producing if non-negative")
 	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce empty values as tombstones")
+	cmd.Flags().IntVarP(&partition, "partition", "p", -1, "the partition to produce to")
 
 	return cmd
 }

--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -25,7 +25,7 @@ func Command(cl *client.Client) *cobra.Command {
 		acks          int
 		retries       int
 		tombstone     bool
-		partition     int
+		partition     int32
 	)
 
 	cmd := &cobra.Command{
@@ -214,9 +214,8 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 					r.Topic = args[0]
 				}
 
-				if partition > -1 {
-					r.Partition = int32(partition)
-				}
+				// Override the partition in the case when the manual partitioner is used.
+				r.Partition = partition
 
 				cl.Client().Produce(context.Background(), r, func(r *kgo.Record, err error) {
 					out.MaybeDie(err, "unable to produce record: %v", err)
@@ -239,7 +238,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required, -1 is all in sync replicas, 1 is leader replica only, 0 is no acks required (0 disables idempotency)")
 	cmd.Flags().IntVar(&retries, "retries", -1, "number of times to retry producing if non-negative")
 	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce empty values as tombstones")
-	cmd.Flags().IntVarP(&partition, "partition", "p", -1, "a specific partition to produce to, if non-negative")
+	cmd.Flags().Int32VarP(&partition, "partition", "p", -1, "a specific partition to produce to, if non-negative")
 
 	return cmd
 }

--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -239,7 +239,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required, -1 is all in sync replicas, 1 is leader replica only, 0 is no acks required (0 disables idempotency)")
 	cmd.Flags().IntVar(&retries, "retries", -1, "number of times to retry producing if non-negative")
 	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce empty values as tombstones")
-	cmd.Flags().IntVarP(&partition, "partition", "p", -1, "the partition to produce to. A negative value (the default) indicates that the default partitioner will be used.")
+	cmd.Flags().IntVarP(&partition, "partition", "p", -1, "a specific partition to produce to, if non-negative")
 
 	return cmd
 }

--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -239,7 +239,7 @@ Unfortunately, with exact sizing, the format string is unavoidably noisy.
 	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required, -1 is all in sync replicas, 1 is leader replica only, 0 is no acks required (0 disables idempotency)")
 	cmd.Flags().IntVar(&retries, "retries", -1, "number of times to retry producing if non-negative")
 	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "produce empty values as tombstones")
-	cmd.Flags().IntVarP(&partition, "partition", "p", -1, "the partition to produce to")
+	cmd.Flags().IntVarP(&partition, "partition", "p", -1, "the partition to produce to. A negative value (the default) indicates that the default partitioner will be used.")
 
 	return cmd
 }


### PR DESCRIPTION
Hello again @twmb - would you consider accepting this additional PR to override the default partitioner on producing messages? Seems like a better implementation might be to also accept partition as part of the format of the produce message so it can be varied per-message, but I don't currently have a use-case for that, so I went with this simple option.