### PR TITLE
fix(myconfig): keep tls when the struct is empty but the tls is required

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -63,7 +63,7 @@ type Cfg struct {
 
 	TimeoutMillis int32 `toml:"timeout_ms,omitempty"`
 
-	TLS  *CfgTLS  `toml:"tls,omitempty"`
+	TLS  *CfgTLS  `toml:"tls,omitzero"`
 	SASL *CfgSASL `toml:"sasl,omitempty"`
 }
 


### PR DESCRIPTION
In servers like Confluent Kafka TLS and SASL is required, but is not required
configure a custom client/ca certificate, so is only necessary keep the `[tls]`
on toml file.

But when the user choose "yes" to the question "tls yes/no?", but do not set the `ca path`, `client cert path` and `tls server name`, the `[tls]` session will not be create and all commands using this connection will fail.

The omitzero will keep the session `[tls]` if the CfgTLS is not nil but all values
of the struct is empty.
