### PR TITLE
chore: add makefile with update-deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: update-deps
+update-deps:
+	go get -u ./...
+	go mod tidy


### PR DESCRIPTION
Run `go get -u ./...` is not enough to keep the `go.(mod|sum)` tidy, so
the `update-deps` will do this job.
