### PR TITLE
CHANGELOG: retarget to v0.18.0; release.sh: bake version + add arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v0.17.0
+v0.18.0
 ===
 
 This is a large release with many intentional breaking changes. Treat
@@ -6,7 +6,7 @@ it as a beta: the new command surface may still shift based on real
 feedback. If you use kcl via shell scripts or automation, read the
 BREAKING section carefully before upgrading.
 
-### BREAKING (migration guide from v0.16.0)
+### BREAKING (migration guide from v0.17.0)
 
 Renames:
 
@@ -140,6 +140,14 @@ Headline additions (see `kcl --help` and the README for details):
   DescribeTopicPartitions handlers).
 * Bumps the rest: aws-sdk-go-v2 family, cobra, pflag, protoreflect,
   crypto, sync, compression libraries.
+
+v0.17.0
+===
+
+* Bumps all deps, notably pulling in franz-go v1.20.0 which can detect
+  Kafka 4.1
+* Builds with Go 1.25.3
+* Fixes `kcl misc raw-req` request pinning
 
 v0.16.0
 ===

--- a/release.sh
+++ b/release.sh
@@ -2,7 +2,21 @@
 
 set -exu
 
-CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build && gzip -9 kcl.exe && mv kcl.exe.gz kcl_windows_amd64.gz
-CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build && gzip -9 kcl && mv kcl.gz kcl_darwin_amd64.gz
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build && gzip -9 kcl && mv kcl.gz kcl_linux_arm64.gz
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build && gzip -9 kcl && mv kcl.gz kcl_linux_amd64.gz
+# Build per-platform binaries, tagging each with the current git
+# describe output so `kcl --version` (and the Kafka wire ClientID)
+# report the release tag instead of a dev pseudo-version.
+VERSION="$(git describe --tags --always --dirty)"
+LDFLAGS="-X main.version=${VERSION}"
+
+build() {
+	local os="$1" arch="$2" exe="$3"
+	CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -ldflags "$LDFLAGS" -o "$exe"
+	gzip -9 "$exe"
+	mv "$exe.gz" "kcl_${os}_${arch}.gz"
+}
+
+build windows amd64 kcl.exe
+build darwin  amd64 kcl
+build darwin  arm64 kcl
+build linux   amd64 kcl
+build linux   arm64 kcl


### PR DESCRIPTION
v0.17.0 was already released (2025-10-17) as a dep bump, so the new entry on this branch is v0.18.0. Added the real v0.17.0 section back, retargeted the migration guide header accordingly.

release.sh:
* Pass -ldflags -X main.version=$(git describe ...) so released binaries' --version (and the Kafka wire ClientID) report the real tag instead of the BuildInfo pseudo-version fallback.
* Add darwin/arm64 and linux/arm64 to the build matrix.
* Factor out a small build() helper to reduce per-platform repetition.