### PR TITLE
misc raw-req: fix --version pinning forcing min on internal requests

### DIFF
--- a/commands/misc/misc.go
+++ b/commands/misc/misc.go
@@ -309,10 +309,17 @@ The wire version used is:
 			}
 			if pinVersion >= 0 {
 				req.SetVersion(pinVersion)
-				vers := kversion.Stable()
-				vers.SetMaxKeyVersion(req.Key(), pinVersion)
-				cl.AddOpt(kgo.MinVersions(vers))
-				cl.AddOpt(kgo.MaxVersions(vers))
+				maxVers := kversion.Stable()
+				maxVers.SetMaxKeyVersion(req.Key(), pinVersion)
+				cl.AddOpt(kgo.MaxVersions(maxVers))
+				// MinVersions is consulted per-request, including
+				// the internal requests franz-go issues (e.g.
+				// Metadata for routing). Only pin the user's key;
+				// leave other keys unset so they negotiate normally
+				// against the broker's actual supported versions.
+				minVers := &kversion.Versions{}
+				minVers.SetMaxKeyVersion(req.Key(), pinVersion)
+				cl.AddOpt(kgo.MinVersions(minVers))
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()


### PR DESCRIPTION
When sending a raw request it seems that API version negotiation is skipped. For example, in Redpanda we do not implement Metadata Request v13 (we probably should, but it seems that is a separate issue). When issues a raw create topics request KCL is requiring v13:

```
nwatkins@acid:~/src/kcl$ echo '{"Topics":[{"Topic":"foo","NumPartitions":1,"ReplicationFactor":1}],"TimeoutMillis":60000,"ValidateOnly":false}' | ./kcl --bootstrap-servers=localhost:9092 misc raw-req -k 19 -v 6
response error: request key 3 version returned has max version 12 below the user defined min of 13
```

Seeding both MinVersions and MaxVersions from kversion.Stable() forced every key's min to the latest stable, so franz-go's internal Metadata call failed against brokers below that version. MaxVersions still needs every key seeded (HasKey is required), but MinVersions can be narrowed to only the pinned key.