### PR TITLE
consume: fix stale -G reference in the internal-topic help

### DIFF
--- a/commands/consume/command.go
+++ b/commands/consume/command.go
@@ -240,7 +240,7 @@ Note that this command allows you to consume the Kafka special internal topics
 __consumer_offsets and __transaction_state. To do so, either of these topics
 must be the only topic specified.
 
-For __consumer_offsets, to dump information about a specific group, use the -G
+For __consumer_offsets, to dump information about a specific group, use the -g
 flag. Doing so will also hide transaction markers. For __transaction_state, you
-can use -G to dump information about a specific transactional ID.
+can use -g to dump information about a specific transactional ID.
 `


### PR DESCRIPTION
The group short flag moved to -g in 6f8cc7d, and f842ad5 then reused -G for --grep. The __consumer_offsets / __transaction_state paragraph still told you to filter with -G, so following it hits the grep parser:

  $ kcl consume __consumer_offsets -G mygroup
  invalid -G "mygroup": unknown prefix; use k:, v:, hk:, hv:, h:NAME=, or t:

The filter is read from c.group, i.e. -g/--group.