### PR TITLE
release.sh: take the version as an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 v0.19.0
 ===
 
+One minor breaking change, caught while auditing the command surface.
+
 ### BREAKING
 
 * `kcl consume` now reads **uncommitted** records by default, matching
@@ -8,11 +10,6 @@ v0.19.0
   the old behavior; `--read-uncommitted` is now a deprecated no-op. The
   old default could not advance past the last stable offset, so one open
   transaction made `kcl consume` print nothing.
-* `kcl acl delete` no longer requires `--type`, `--pattern`,
-  `--operation`, and `--permission`; unspecified filters match
-  everything, as in rpk and `kafka-acls.sh`. The confirmation prompt,
-  which lists every match first, is the guard. A bare `kcl acl delete`
-  now matches all ACLs rather than erroring.
 
 ### NEW
 
@@ -44,6 +41,11 @@ v0.19.0
 * `kcl cluster describe-cluster` is now `kcl cluster describe`, with the
   old name kept as an alias. It and `kcl cluster metadata` now name the
   RPC each issues, since the two overlap.
+* `kcl acl delete` no longer requires `--type`, `--pattern`,
+  `--operation`, and `--permission`; unspecified filters match
+  everything, as in rpk and `kafka-acls.sh`. The confirmation prompt,
+  which lists every match first, is the guard. A bare `kcl acl delete`
+  now matches all ACLs rather than erroring.
 * `kcl acl` spells its filters `--operation` and `--permission`, matching
   `kafka-acls.sh` and rpk. `--op` and `--perm` still work and are named
   in each flag's help.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ kcl
 
 - [Introduction](#introduction)
 - [Getting Started / Installation](#getting-started)
-- [Stability Status](#stability-status)
 - [Configuration](#configuration)
 - [Autocompletion](#autocompletion)
 - [Group Consuming](#group-consuming)
@@ -27,20 +26,6 @@ producing formatting options, and a complete Kafka administration
 interface that tracks the upstream protocol closely.
 
 [1]: https://github.com/confluentinc/kcat
-
-## Stability Status
-
-Treat the current command surface as a beta. The v0.17.0 release made a
-large, deliberate set of breaking changes across flags, config, and
-command layout (see the CHANGELOG for the full list). Further breaks
-are possible as users exercise the new surface and surface issues;
-that feedback is explicitly welcome.
-
-I've spent significant time integration testing my [franz-go][2] client that
-this program uses. It is worth reading the stability status in the franz-go
-repo as well if using this client.
-
-[2]: https://github.com/twmb/franz-go/
 
 ## Getting Started
 

--- a/release.sh
+++ b/release.sh
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-set -exu
+set -eu
 
-# Build per-platform binaries, tagging each with the current git
-# describe output so `kcl --version` (and the Kafka wire ClientID)
-# report the release tag instead of a dev pseudo-version.
-VERSION="$(git describe --tags --always --dirty)"
+# Build per-platform binaries with the release version baked in, so that
+# `kcl --version` (and the Kafka wire ClientID) report it rather than a dev
+# pseudo-version.
+#
+# The version is an argument rather than `git describe` output: the binaries
+# are built before the tag is created, so describing HEAD produced the
+# previous tag plus a commit distance, e.g. "v0.18.0-30-g66f4393".
+
+if [ $# -ne 1 ]; then
+	echo "usage: $0 VERSION" >&2
+	echo "   eg: $0 v0.19.0" >&2
+	exit 1
+fi
+
+VERSION="$1"
+
+# A dirty tree does not build the release it claims to; say so in the binary
+# rather than shipping something that cannot be reproduced from the tag.
+if [ -n "$(git status --porcelain)" ]; then
+	VERSION="${VERSION}-dirty"
+	echo "warning: working tree is dirty, building ${VERSION}" >&2
+fi
+
+set -x
 LDFLAGS="-X main.version=${VERSION}"
 
 build() {


### PR DESCRIPTION
Three things, all found while getting the release ready.

## `release.sh` baked the wrong version

It derived the version from git:

```bash
VERSION="$(git describe --tags --always --dirty)"
```

But the binaries are built *before* the tag is created, so describing HEAD returns the previous tag plus a commit distance. Run on master today it produces:

```
+ go build -ldflags '-X main.version=v0.18.0-31-g4f1c345' -o kcl_linux_arm64
$ ./kcl_darwin_arm64 --version
kcl version v0.18.0-31-g4f1c345
```

All five binaries, and the Kafka wire ClientID too, so it would reach broker audit logs. v0.18.0 shipped correctly only because its tag happened to exist before the build — the tag commit and the release share a timestamp to the second. Nothing enforced that order.

The version is now an argument:

```
$ ./release.sh
usage: ./release.sh VERSION
   eg: ./release.sh v0.19.0

$ ./release.sh v0.19.0
+ go build -ldflags '-X main.version=v0.19.0' -o kcl_linux_amd64
$ ./kcl_darwin_arm64 --version
kcl version v0.19.0
```

Running with no argument is an error rather than a wrong build. A dirty tree still marks the version (`v0.19.0-dirty`), since such a build cannot be reproduced from the tag.

## Stability Status section removed

Its `[2]` franz-go link reference was used nowhere else, so nothing dangles. The TOC entry is gone too. Remaining link refs are `[1]`, `[3]`, `[4]`, `[5]` — the numbering gap is inert.

## `acl delete` moved out of BREAKING

Nothing that previously worked behaves differently — it is a relaxation, not a break. It is now a `NEW` entry beside the other `acl` flag change, and the release has one breaking change rather than two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
