### PR TITLE
Publish official container images to ghcr.io on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .git
 .github
 *.md
-CHANGELOG.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+*.md
+CHANGELOG.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,8 @@ jobs:
       # exactly the code most likely to have a data race.
       - name: test
         run: go test -race -count=1 ./...
+
+      # The release image is otherwise first built after a GitHub Release is
+      # already public, so catch a broken Dockerfile here.
+      - name: docker build
+        run: docker build --build-arg VERSION=ci .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
-      - uses: docker/setup-qemu-action@v4
-
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -43,9 +41,14 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
+          # Label the image with the commit that was checked out and built,
+          # not the branch a workflow_dispatch was started from.
+          context: git
           tags: |
             type=raw,value=${{ steps.tag.outputs.tag }}
-            type=raw,value=latest,enable=${{ github.event.release.prerelease != true }}
+            # null != true is true on workflow_dispatch, which would move
+            # :latest to whatever tag was dispatched.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
 
       - uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: docker
+
+# Fires on the same event the maintainer already produces by hand (build
+# with release.sh, tag, then publish a GitHub Release with the binaries
+# attached) -- so this needs no change to that flow. workflow_dispatch lets
+# an already-published release be (re)built without cutting a new one.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build, e.g. v0.19.0"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: resolve tag
+        id: tag
+        run: echo "tag=${{ github.event.release.tag_name || github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ steps.tag.outputs.tag }}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease != true }}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ steps.tag.outputs.tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+# Build natively on BUILDPLATFORM and cross-compile the (CGO-free) Go binary
+# for TARGETARCH, same as release.sh -- avoids paying for QEMU emulation on
+# every multi-arch build.
+FROM --platform=$BUILDPLATFORM golang:1.26 AS build
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+	go build -ldflags "-X main.version=${VERSION}" -o /out/kcl .
+
+# distroless/static: no shell, no package manager, just a CA bundle -- kcl is
+# a static binary and only needs certs for TLS-secured Kafka/Schema Registry.
+FROM gcr.io/distroless/static-debian13:nonroot
+COPY --from=build /out/kcl /usr/local/bin/kcl
+ENTRYPOINT ["/usr/local/bin/kcl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Build natively on BUILDPLATFORM and cross-compile the (CGO-free) Go binary
 # for TARGETARCH, same as release.sh -- avoids paying for QEMU emulation on
 # every multi-arch build.
-FROM --platform=$BUILDPLATFORM golang:1.26 AS build
+FROM --platform=$BUILDPLATFORM golang:1 AS build
 WORKDIR /src
 
 COPY go.mod go.sum ./
@@ -19,6 +19,6 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
 
 # distroless/static: no shell, no package manager, just a CA bundle -- kcl is
 # a static binary and only needs certs for TLS-secured Kafka/Schema Registry.
-FROM gcr.io/distroless/static-debian13:nonroot
+FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/kcl /usr/local/bin/kcl
 ENTRYPOINT ["/usr/local/bin/kcl"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ protocol's client ID (useful for ACL audit logs and broker-side metrics).
 Otherwise, download a release from the
 [releases](https://github.com/twmb/kcl/releases) page.
 
+A container image is also published for each release, useful as a
+short-lived Kubernetes or CI client:
+
+```bash
+kubectl run kafka-client --rm -it --restart=Never \
+  --image=ghcr.io/twmb/kcl:v0.19.0 \
+  -- --no-config-file -B kafka-headless:9092 topic list
+```
+
+(the image's entrypoint is already `kcl`, so args after `--` go straight to it)
+
 ## Configuration
 
 kcl is usable out of the box against `localhost:9092`; no config is required

--- a/README.md
+++ b/README.md
@@ -47,12 +47,16 @@ A container image is also published for each release, useful as a
 short-lived Kubernetes or CI client:
 
 ```bash
-kubectl run kafka-client --rm -it --restart=Never \
-  --image=ghcr.io/twmb/kcl:v0.19.0 \
+kubectl run kafka-client --rm -i --restart=Never \
+  --image=ghcr.io/twmb/kcl:latest \
   -- --no-config-file -B kafka-headless:9092 topic list
 ```
 
-(the image's entrypoint is already `kcl`, so args after `--` go straight to it)
+(the image's entrypoint is already `kcl`, so args after `--` go straight to it;
+suffix the image with `:v#.#.#` for a specific release)
+
+The image has no shell, so it cannot serve as a CI job's container; run it
+from a step with `docker run` or `kubectl run`.
 
 ## Configuration
 


### PR DESCRIPTION
Fixes #58 

Adds a distroless-based multi-arch (amd64/arm64) Docker image and a release-triggered workflow that publishes it to ghcr.io/twmb/kcl, so Kubernetes/CI users can run kcl without maintaining their own wrapper image (#58).

- Dockerfile cross-compiles the static Go binary for TARGETARCH on the BUILDPLATFORM golang image (same pattern as release.sh), then copies it onto gcr.io/distroless/static-debian13:nonroot -- no shell, no package manager, just a CA bundle for TLS-secured Kafka/Schema Registry connections.
- .github/workflows/docker.yml fires on `release: published`, matching the existing release.sh + manual GitHub Release flow, so no change is needed there. workflow_dispatch allows backfilling an already-published release. Builds linux/amd64 + linux/arm64, tags ghcr.io/twmb/kcl:<tag> and :latest (skipped for prereleases).
- README documents the image with the kubectl example from the issue.