### PR TITLE
profile: lay the file over the defaults, describe keys, unset, env refs, exit 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The configuration supports TLS, SASL (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512,
 AWS_MSK_IAM), seed brokers, and client/server timeouts. Timeouts accept Go
 duration strings (`500ms`, `5s`, `2m30s`).
 
-`kcl profile keys` lists every key with its meaning.
+`kcl -X help` describes every key; `kcl -X list` names them.
 
 `kcl profile create` writes a profile from the same flags a one-off command
 takes:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The configuration supports TLS, SASL (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512,
 AWS_MSK_IAM), seed brokers, and client/server timeouts. Timeouts accept Go
 duration strings (`500ms`, `5s`, `2m30s`).
 
-For a full reference with examples, run `kcl profile --help`.
+`kcl profile keys` lists every key with its meaning.
 
 `kcl profile create` writes a profile from the same flags a one-off command
 takes:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ kcl profile create cicd -B kafka-staging:9092 -X dial_timeout=2s -X sasl.method=
 ```
 
 If nothing is current yet, the new profile is; otherwise `kcl profile use NAME`.
+A value may reference an environment variable as `${NAME}`, so a password can
+live in your environment rather than in the file.
 `kcl profile set` applies the same flags to the current profile, or to the one
 `-C` names.
 

--- a/client/client.go
+++ b/client/client.go
@@ -479,12 +479,127 @@ func (c *Client) LoadedCfgFile() CfgFile {
 // (-X tls.insecure) to mean true. A table takes only the empty value, which
 // removes the whole table. An empty value (-X sasl.pass=) unsets any key.
 type CfgKey struct {
-	Name string
-	Desc string
-	Type string
+	Name    string
+	Example string
+	Desc    string
+	Type    string
 
 	set    func(*Cfg, string) error
 	hidden bool // an old name that only errors
+}
+
+// XList renders every key as KEY=EXAMPLE, one per line, the short form of
+// -X help and the source for -X tab completion.
+func XList() string {
+	var b strings.Builder
+	for _, k := range CfgKeys() {
+		fmt.Fprintf(&b, "%s=%s\n", k.Name, k.Example)
+	}
+	return b.String()
+}
+
+// XCompletions returns completions for the -X flag: each key with a
+// trailing =, described by its example.
+func XCompletions() []string {
+	var cs []string
+	for _, k := range CfgKeys() {
+		cs = append(cs, k.Name+"=\t"+k.Example)
+	}
+	return cs
+}
+
+const xHelpIntro = `-X KEY=VALUE sets one configuration key for this command and may be
+repeated. The same keys are read from the environment as KCL_<KEY>, with dots
+as underscores (KCL_SASL_USER), and from the config file, where a profile is a
+[profiles.NAME] table. Flags win over the environment, which wins over the
+file, which wins over the defaults; only keys that are set take effect.
+
+An empty value unsets a key (-X sasl.pass=). A bool may be given bare
+(-X tls.insecure). The table keys tls, sasl, registry, and registry.tls take
+only the empty value and remove the whole table. A value may reference an
+environment variable as ${NAME}; $${ is a literal ${. A config file can name
+any environment variable this way, so treat a file you did not write like a
+script.
+
+-X list prints the keys alone. --format json or awk prints them as data.
+Each key below is shown with an example value.
+`
+
+const xHelpTimeouts = `TIMEOUTS
+
+dial_timeout is caller side, per TCP dial attempt. retry_timeout is client
+side and gates whether to START a retry; it is not a wall clock budget, so an
+in-flight attempt is not cancelled when it elapses. broker_timeout is sent to
+the broker and enforced there, only on requests that carry a TimeoutMs field.
+
+Keep dial_timeout <= broker_timeout <= retry_timeout. retry_timeout is only
+consulted when an attempt errors, so a slow but successful reply still
+succeeds and one retry can run to about twice broker_timeout in total. If
+dial_timeout is at or above retry_timeout, one failed dial uses the whole
+retry budget and nothing is retried.
+`
+
+// XHelp renders the long form of -X help: an intro, every key as
+// KEY=EXAMPLE with its description beneath, and the timeout guidance.
+func XHelp() string {
+	var b strings.Builder
+	b.WriteString(xHelpIntro)
+	for _, k := range CfgKeys() {
+		fmt.Fprintf(&b, "\n%s=%s\n%s", k.Name, k.Example, wrap(k.Desc, 76, "  "))
+	}
+	b.WriteString("\n" + xHelpTimeouts)
+	return b.String()
+}
+
+// wrap word wraps s to width, prefixing every line with indent.
+func wrap(s string, width int, indent string) string {
+	var b strings.Builder
+	line := indent
+	for _, word := range strings.Fields(s) {
+		if len(line) > len(indent) && len(line)+1+len(word) > width {
+			b.WriteString(line + "\n")
+			line = indent
+		}
+		if len(line) > len(indent) {
+			line += " "
+		}
+		line += word
+	}
+	if len(line) > len(indent) {
+		b.WriteString(line + "\n")
+	}
+	return b.String()
+}
+
+// MaybeXHelp answers -X help and -X list: it prints the keys in the current
+// --format and reports true, or does nothing and reports false.
+func (c *Client) MaybeXHelp() bool {
+	var long, short bool
+	for _, x := range c.flagOverrides {
+		switch x {
+		case "help":
+			long = true
+		case "list":
+			short = true
+		}
+	}
+	if !long && !short {
+		return false
+	}
+	if c.Format() != out.FormatText {
+		table := out.NewFormattedTable(c.Format(), "keys", 1, "keys", "KEY", "TYPE", "EXAMPLE", "DESCRIPTION")
+		for _, k := range CfgKeys() {
+			table.Row(k.Name, k.Type, k.Example, k.Desc)
+		}
+		table.Flush()
+		return true
+	}
+	if long {
+		fmt.Print(XHelp())
+	} else {
+		fmt.Print(XList())
+	}
+	return true
 }
 
 // CfgKeys returns every -X key kcl accepts, in display order.
@@ -568,8 +683,8 @@ func intoStrSlice(in string, dst *[]string) error {
 	return nil
 }
 
-func str(name, desc string, t cfgTable, f func(*Cfg) *string) CfgKey {
-	return CfgKey{Name: name, Desc: desc, Type: "string", set: func(c *Cfg, v string) error {
+func str(name, example, desc string, t cfgTable, f func(*Cfg) *string) CfgKey {
+	return CfgKey{Name: name, Example: example, Desc: desc, Type: "string", set: func(c *Cfg, v string) error {
 		if v == "" && !t.has(c) {
 			return nil
 		}
@@ -580,7 +695,7 @@ func str(name, desc string, t cfgTable, f func(*Cfg) *string) CfgKey {
 }
 
 func boolean(name, desc string, t cfgTable, f func(*Cfg) *bool) CfgKey {
-	return CfgKey{Name: name, Desc: desc, Type: "bool", set: func(c *Cfg, v string) error {
+	return CfgKey{Name: name, Example: "true", Desc: desc, Type: "bool", set: func(c *Cfg, v string) error {
 		b, err := parseBoolOpt(v)
 		if err != nil {
 			return err
@@ -594,8 +709,8 @@ func boolean(name, desc string, t cfgTable, f func(*Cfg) *bool) CfgKey {
 	}}
 }
 
-func list(name, desc string, t cfgTable, f func(*Cfg) *[]string) CfgKey {
-	return CfgKey{Name: name, Desc: desc, Type: "list", set: func(c *Cfg, v string) error {
+func list(name, example, desc string, t cfgTable, f func(*Cfg) *[]string) CfgKey {
+	return CfgKey{Name: name, Example: example, Desc: desc, Type: "list", set: func(c *Cfg, v string) error {
 		if v == "" {
 			if t.has(c) {
 				*f(c) = nil
@@ -607,8 +722,8 @@ func list(name, desc string, t cfgTable, f func(*Cfg) *[]string) CfgKey {
 	}}
 }
 
-func duration(name, desc string, f func(*Cfg) **Duration) CfgKey {
-	return CfgKey{Name: name, Desc: desc, Type: "duration", set: func(c *Cfg, v string) error {
+func duration(name, example, desc string, f func(*Cfg) **Duration) CfgKey {
+	return CfgKey{Name: name, Example: example, Desc: desc, Type: "duration", set: func(c *Cfg, v string) error {
 		if v == "" {
 			*f(c) = nil
 			return nil
@@ -647,29 +762,29 @@ func parseBoolOpt(v string) (bool, error) {
 func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, who string) []CfgKey {
 	d := func(desc string) string { return who + desc }
 	return []CfgKey{
-		table(prefix, d("The TLS table. "+prefix+"= removes it, turning TLS off."), t),
-		str(prefix+".ca_cert_path", d("PEM file holding the CA that signed the server certificates."), t, func(c *Cfg) *string { return &tls(c).CACert }),
-		str(prefix+".client_cert_path", d("PEM client certificate, for mutual TLS."), t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
-		str(prefix+".client_key_path", d("PEM client key, for mutual TLS."), t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
-		str(prefix+".server_name", d("Name to verify the server certificate against, when it is not the host dialed."), t, func(c *Cfg) *string { return &tls(c).ServerName }),
-		boolean(prefix+".insecure", d("Skip certificate verification."), t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
-		str(prefix+".min_version", d("Lowest TLS version accepted: 1.0, 1.1, 1.2, or 1.3. Default 1.2."), t, func(c *Cfg) *string { return &tls(c).MinVersion }),
-		list(prefix+".cipher_suites", d("Cipher suites allowed, by Go name, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
-		list(prefix+".curve_preferences", d("Curves allowed for key exchange, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
+		table(prefix, d("The TLS table. Setting any "+prefix+".* key turns TLS on; "+prefix+"= removes the table, turning it off."), t),
+		str(prefix+".ca_cert_path", "/etc/kafka/ca.pem", d("PEM file holding the CA that signed the server certificates. Needed when the CA is not in the system roots."), t, func(c *Cfg) *string { return &tls(c).CACert }),
+		str(prefix+".client_cert_path", "/etc/kafka/client.pem", d("PEM client certificate, for mutual TLS. Set with "+prefix+".client_key_path."), t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
+		str(prefix+".client_key_path", "/etc/kafka/client.key", d("PEM client key, for mutual TLS."), t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
+		str(prefix+".server_name", "kafka.example.com", d("Name to verify the server certificate against, when it is not the host dialed."), t, func(c *Cfg) *string { return &tls(c).ServerName }),
+		boolean(prefix+".insecure", d("Skip certificate verification. The connection is still encrypted, but anyone can sit in the middle of it."), t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
+		str(prefix+".min_version", "1.3", d("Lowest TLS version accepted: 1.0, 1.1, 1.2, or 1.3. Default 1.2."), t, func(c *Cfg) *string { return &tls(c).MinVersion }),
+		list(prefix+".cipher_suites", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", d("Cipher suites allowed, by Go name, comma separated. Default is Go's list."), t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
+		list(prefix+".curve_preferences", "X25519,P256", d("Curves allowed for key exchange, comma separated. Default is Go's list."), t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
 	}
 }
 
-// cfgKeys is every -X key, in the order kcl profile keys lists them.
+// cfgKeys is every -X key, in the order kcl -X help lists them.
 var cfgKeys = func() []CfgKey {
 	keys := []CfgKey{
-		list("seed_brokers", "Brokers to connect to, host:port, comma separated. Default localhost:9092.", topTable, func(c *Cfg) *[]string { return &c.SeedBrokers }),
-		duration("broker_timeout", "How long the broker may spend on an admin request, sent as the wire TimeoutMs. Default 5s.", func(c *Cfg) **Duration { return &c.BrokerTimeout }),
-		duration("dial_timeout", "Bound on one TCP dial. Unset uses kgo's 10s.", func(c *Cfg) **Duration { return &c.DialTimeout }),
-		duration("retry_timeout", "Bound on a request and its retries. Unset uses kgo's 30s, 45s for group requests.", func(c *Cfg) **Duration { return &c.RetryTimeout }),
+		list("seed_brokers", "host1:9092,host2:9092", "Brokers to connect to, host:port, comma separated. Any one of them is enough to find the rest. Default localhost:9092.", topTable, func(c *Cfg) *[]string { return &c.SeedBrokers }),
+		duration("broker_timeout", "5s", "How long the broker may spend on an admin request such as creating a topic, sent as the wire TimeoutMs. Default 5s.", func(c *Cfg) **Duration { return &c.BrokerTimeout }),
+		duration("dial_timeout", "2s", "Bound on one TCP dial. Unset uses kgo's 10s.", func(c *Cfg) **Duration { return &c.DialTimeout }),
+		duration("retry_timeout", "30s", "Bound on a request and its retries. Unset uses kgo's 30s, 45s for group requests.", func(c *Cfg) **Duration { return &c.RetryTimeout }),
 		{Name: "timeout_ms", hidden: true, set: func(*Cfg, string) error {
 			return fmt.Errorf("timeout_ms was renamed to broker_timeout and now takes a Go duration (e.g. -X broker_timeout=5s); please update your config or -X flags")
 		}},
-		{Name: "use_tls", Type: "bool", Desc: "true turns TLS on with the system roots; false removes the tls table.", set: func(c *Cfg, v string) error {
+		{Name: "use_tls", Example: "true", Type: "bool", Desc: "true turns TLS on with the system roots; false removes the tls table. Setting any tls.* key turns TLS on as well.", set: func(c *Cfg, v string) error {
 			b, err := parseBoolOpt(v)
 			if err != nil {
 				return err
@@ -684,18 +799,18 @@ var cfgKeys = func() []CfgKey {
 	}
 	keys = append(keys, tlsKeys("tls", tlsTable, func(c *Cfg) *CfgTLS { return c.TLS }, "")...)
 	keys = append(keys,
-		table("sasl", "The SASL table. sasl= removes it.", saslTable),
-		str("sasl.method", "plain, scram-sha-256, scram-sha-512, or aws_msk_iam.", saslTable, func(c *Cfg) *string { return &c.SASL.Method }),
-		str("sasl.zid", "Authorization id, when it differs from the user.", saslTable, func(c *Cfg) *string { return &c.SASL.Zid }),
-		str("sasl.user", "User name.", saslTable, func(c *Cfg) *string { return &c.SASL.User }),
-		str("sasl.pass", "Password.", saslTable, func(c *Cfg) *string { return &c.SASL.Pass }),
+		table("sasl", "The SASL table. sasl= removes it, turning authentication off.", saslTable),
+		str("sasl.method", "scram-sha-256", "plain, scram-sha-256, scram-sha-512, or aws_msk_iam; case and dashes do not matter.", saslTable, func(c *Cfg) *string { return &c.SASL.Method }),
+		str("sasl.zid", "", "Authorization id, when it differs from the user. Rarely needed.", saslTable, func(c *Cfg) *string { return &c.SASL.Zid }),
+		str("sasl.user", "alice", "User name.", saslTable, func(c *Cfg) *string { return &c.SASL.User }),
+		str("sasl.pass", "${KAFKA_PASS}", "Password. A reference like ${KAFKA_PASS} reads the environment when kcl starts, so the password need not sit in the file.", saslTable, func(c *Cfg) *string { return &c.SASL.Pass }),
 		boolean("sasl.is_token", "The password is a delegation token.", saslTable, func(c *Cfg) *bool { return &c.SASL.IsToken }),
 		table("registry", "The schema registry table. registry= removes it.", srTable),
-		list("registry.urls", "Schema registry URLs, comma separated. Default http://localhost:8081.", srTable, func(c *Cfg) *[]string { return &c.SR.URLs }),
-		str("registry.user", "Basic auth user name.", srTable, func(c *Cfg) *string { return &c.SR.User }),
-		str("registry.pass", "Basic auth password.", srTable, func(c *Cfg) *string { return &c.SR.Pass }),
-		str("registry.bearer_token", "Bearer token, in place of basic auth.", srTable, func(c *Cfg) *string { return &c.SR.BearerToken }),
-		str("registry.context", "Registry context that scopes every request.", srTable, func(c *Cfg) *string { return &c.SR.Context }),
+		list("registry.urls", "http://sr1:8081,http://sr2:8081", "Schema registry URLs, comma separated. Default http://localhost:8081.", srTable, func(c *Cfg) *[]string { return &c.SR.URLs }),
+		str("registry.user", "alice", "Basic auth user name.", srTable, func(c *Cfg) *string { return &c.SR.User }),
+		str("registry.pass", "${SR_PASS}", "Basic auth password.", srTable, func(c *Cfg) *string { return &c.SR.Pass }),
+		str("registry.bearer_token", "${SR_TOKEN}", "Bearer token, in place of basic auth.", srTable, func(c *Cfg) *string { return &c.SR.BearerToken }),
+		str("registry.context", ".mycontext", "Registry context that scopes every request.", srTable, func(c *Cfg) *string { return &c.SR.Context }),
 	)
 	keys = append(keys, tlsKeys("registry.tls", srTLSTable, func(c *Cfg) *CfgTLS { return c.SR.TLS }, "Registry: ")...)
 	return keys
@@ -720,7 +835,7 @@ func ApplyCfgOpts(cfg *Cfg, opts []string) error {
 		k, v, hasEq := strings.Cut(opt, "=")
 		key, exists := cfgSetters[normCfgKey(k)]
 		if !exists {
-			return fmt.Errorf("unknown opt key %q; kcl profile keys lists them", k)
+			return fmt.Errorf("unknown opt key %q; see kcl -X help", k)
 		}
 		if !hasEq {
 			if key.Type != "bool" {

--- a/client/client.go
+++ b/client/client.go
@@ -264,7 +264,7 @@ func New(root *cobra.Command) *Client {
 
 	root.PersistentFlags().StringVar(&c.logLevel, "log-level", "none", "log level to use for basic logging (none, error, warn, info, debug)")
 	root.PersistentFlags().StringVar(&c.logFile, "log-file", "STDERR", "log to this file (if log-level is not none; file must not exist; STDERR sets to stderr & STDOUT sets to stdout)")
-	root.PersistentFlags().StringVar(&c.cfgPath, "config-path", c.defaultCfgPath, "path to confile file (lowest priority)")
+	root.PersistentFlags().StringVar(&c.cfgPath, "config-path", c.defaultCfgPath, "path to config file (lowest priority)")
 	root.PersistentFlags().BoolVar(&c.noCfgFile, "no-config-file", false, "do not load any config file")
 	root.PersistentFlags().StringVar(&c.envPfx, "config-env-prefix", "KCL_", "environment variable prefix for config overrides (middle priority)")
 	root.PersistentFlags().StringArrayVarP(&c.flagOverrides, "config-opt", "X", nil, "flag provided config option (highest priority)")
@@ -644,17 +644,18 @@ func parseBoolOpt(v string) (bool, error) {
 	return b, nil
 }
 
-func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, suffix string) []CfgKey {
+func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, who string) []CfgKey {
+	d := func(desc string) string { return who + desc }
 	return []CfgKey{
-		table(prefix, "The TLS table. "+prefix+"= removes it, turning TLS off"+suffix+".", t),
-		str(prefix+".ca_cert_path", "PEM file holding the CA that signed the server certificates"+suffix+".", t, func(c *Cfg) *string { return &tls(c).CACert }),
-		str(prefix+".client_cert_path", "PEM client certificate, for mutual TLS"+suffix+".", t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
-		str(prefix+".client_key_path", "PEM client key, for mutual TLS"+suffix+".", t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
-		str(prefix+".server_name", "Name to verify the server certificate against, when it is not the host dialed"+suffix+".", t, func(c *Cfg) *string { return &tls(c).ServerName }),
-		boolean(prefix+".insecure", "Skip certificate verification"+suffix+".", t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
-		str(prefix+".min_version", "Lowest TLS version accepted: 1.0, 1.1, 1.2, or 1.3. Default 1.2"+suffix+".", t, func(c *Cfg) *string { return &tls(c).MinVersion }),
-		list(prefix+".cipher_suites", "Cipher suites allowed, by Go name, comma separated"+suffix+".", t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
-		list(prefix+".curve_preferences", "Curves allowed for key exchange, comma separated"+suffix+".", t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
+		table(prefix, d("The TLS table. "+prefix+"= removes it, turning TLS off."), t),
+		str(prefix+".ca_cert_path", d("PEM file holding the CA that signed the server certificates."), t, func(c *Cfg) *string { return &tls(c).CACert }),
+		str(prefix+".client_cert_path", d("PEM client certificate, for mutual TLS."), t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
+		str(prefix+".client_key_path", d("PEM client key, for mutual TLS."), t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
+		str(prefix+".server_name", d("Name to verify the server certificate against, when it is not the host dialed."), t, func(c *Cfg) *string { return &tls(c).ServerName }),
+		boolean(prefix+".insecure", d("Skip certificate verification."), t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
+		str(prefix+".min_version", d("Lowest TLS version accepted: 1.0, 1.1, 1.2, or 1.3. Default 1.2."), t, func(c *Cfg) *string { return &tls(c).MinVersion }),
+		list(prefix+".cipher_suites", d("Cipher suites allowed, by Go name, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
+		list(prefix+".curve_preferences", d("Curves allowed for key exchange, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
 	}
 }
 
@@ -696,7 +697,7 @@ var cfgKeys = func() []CfgKey {
 		str("registry.bearer_token", "Bearer token, in place of basic auth.", srTable, func(c *Cfg) *string { return &c.SR.BearerToken }),
 		str("registry.context", "Registry context that scopes every request.", srTable, func(c *Cfg) *string { return &c.SR.Context }),
 	)
-	keys = append(keys, tlsKeys("registry.tls", srTLSTable, func(c *Cfg) *CfgTLS { return c.SR.TLS }, " for the registry")...)
+	keys = append(keys, tlsKeys("registry.tls", srTLSTable, func(c *Cfg) *CfgTLS { return c.SR.TLS }, "Registry: ")...)
 	return keys
 }()
 

--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -468,119 +469,260 @@ func (c *Client) LoadedCfgFile() CfgFile {
 	return c.cfgFile
 }
 
-// cfgSetters maps every config key, in its normalized underscore form, to
-// the function that sets it. See normCfgKey.
-var cfgSetters = func() map[string]func(*Cfg, string) error {
-	intoStrSlice := func(in string, dst *[]string) error {
-		*dst = nil
-		split := strings.Split(in, ",")
-		for _, on := range split {
-			on = strings.TrimSpace(on)
-			if len(on) == 0 {
-				return fmt.Errorf("invalid empty value in %q", in)
+// CfgKey is one -X key: its dotted name, what it does, and its Type, one of
+// string, list, duration, bool, or table. A bool may be given bare
+// (-X tls.insecure) to mean true. A table takes only the empty value, which
+// removes the whole table. An empty value (-X sasl.pass=) unsets any key.
+type CfgKey struct {
+	Name string
+	Desc string
+	Type string
+
+	set    func(*Cfg, string) error
+	hidden bool // an old name that only errors
+}
+
+// CfgKeys returns every -X key kcl accepts, in display order.
+func CfgKeys() []CfgKey {
+	var keys []CfgKey
+	for _, k := range cfgKeys {
+		if !k.hidden {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// A cfgTable knows how to find, create, and remove one optional table of
+// Cfg. Unsetting a key in a table that does not exist leaves the table
+// absent, since an empty [tls] table is itself a setting.
+type cfgTable struct {
+	has func(*Cfg) bool
+	mk  func(*Cfg)
+	rm  func(*Cfg)
+}
+
+var (
+	topTable = cfgTable{has: func(*Cfg) bool { return true }, mk: func(*Cfg) {}}
+
+	tlsTable = cfgTable{
+		has: func(c *Cfg) bool { return c.TLS != nil },
+		mk: func(c *Cfg) {
+			if c.TLS == nil {
+				c.TLS = new(CfgTLS)
 			}
-			*dst = append(*dst, on)
+		},
+		rm: func(c *Cfg) { c.TLS = nil },
+	}
+
+	saslTable = cfgTable{
+		has: func(c *Cfg) bool { return c.SASL != nil },
+		mk: func(c *Cfg) {
+			if c.SASL == nil {
+				c.SASL = new(CfgSASL)
+			}
+		},
+		rm: func(c *Cfg) { c.SASL = nil },
+	}
+
+	srTable = cfgTable{
+		has: func(c *Cfg) bool { return c.SR != nil },
+		mk: func(c *Cfg) {
+			if c.SR == nil {
+				c.SR = new(CfgSR)
+			}
+		},
+		rm: func(c *Cfg) { c.SR = nil },
+	}
+
+	srTLSTable = cfgTable{
+		has: func(c *Cfg) bool { return c.SR != nil && c.SR.TLS != nil },
+		mk: func(c *Cfg) {
+			srTable.mk(c)
+			if c.SR.TLS == nil {
+				c.SR.TLS = new(CfgTLS)
+			}
+		},
+		rm: func(c *Cfg) {
+			if c.SR != nil {
+				c.SR.TLS = nil
+			}
+		},
+	}
+)
+
+func intoStrSlice(in string, dst *[]string) error {
+	*dst = nil
+	for _, on := range strings.Split(in, ",") {
+		on = strings.TrimSpace(on)
+		if len(on) == 0 {
+			return fmt.Errorf("invalid empty value in %q", in)
 		}
+		*dst = append(*dst, on)
+	}
+	return nil
+}
+
+func str(name, desc string, t cfgTable, f func(*Cfg) *string) CfgKey {
+	return CfgKey{Name: name, Desc: desc, Type: "string", set: func(c *Cfg, v string) error {
+		if v == "" && !t.has(c) {
+			return nil
+		}
+		t.mk(c)
+		*f(c) = v
 		return nil
-	}
+	}}
+}
 
-	mktls := func(c *Cfg) {
-		if c.TLS == nil {
-			c.TLS = new(CfgTLS)
+func boolean(name, desc string, t cfgTable, f func(*Cfg) *bool) CfgKey {
+	return CfgKey{Name: name, Desc: desc, Type: "bool", set: func(c *Cfg, v string) error {
+		b, err := parseBoolOpt(v)
+		if err != nil {
+			return err
 		}
-	}
-
-	mksasl := func(c *Cfg) {
-		if c.SASL == nil {
-			c.SASL = new(CfgSASL)
+		if !b && !t.has(c) {
+			return nil
 		}
-	}
+		t.mk(c)
+		*f(c) = b
+		return nil
+	}}
+}
 
-	mksr := func(c *Cfg) {
-		if c.SR == nil {
-			c.SR = new(CfgSR)
+func list(name, desc string, t cfgTable, f func(*Cfg) *[]string) CfgKey {
+	return CfgKey{Name: name, Desc: desc, Type: "list", set: func(c *Cfg, v string) error {
+		if v == "" {
+			if t.has(c) {
+				*f(c) = nil
+			}
+			return nil
 		}
-	}
+		t.mk(c)
+		return intoStrSlice(v, f(c))
+	}}
+}
 
-	mksrtls := func(c *Cfg) {
-		mksr(c)
-		if c.SR.TLS == nil {
-			c.SR.TLS = new(CfgTLS)
+func duration(name, desc string, f func(*Cfg) **Duration) CfgKey {
+	return CfgKey{Name: name, Desc: desc, Type: "duration", set: func(c *Cfg, v string) error {
+		if v == "" {
+			*f(c) = nil
+			return nil
 		}
-	}
-
-	intoDuration := func(v string, dst **Duration) error {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			return fmt.Errorf("invalid duration %q: %v", v, err)
 		}
-		*dst = Dur(d)
+		*f(c) = Dur(d)
 		return nil
-	}
+	}}
+}
 
-	fns := map[string]func(*Cfg, string) error{
-		"seed_brokers":   func(c *Cfg, v string) error { return intoStrSlice(v, &c.SeedBrokers) },
-		"broker_timeout": func(c *Cfg, v string) error { return intoDuration(v, &c.BrokerTimeout) },
-		"dial_timeout":   func(c *Cfg, v string) error { return intoDuration(v, &c.DialTimeout) },
-		"retry_timeout":  func(c *Cfg, v string) error { return intoDuration(v, &c.RetryTimeout) },
-		// Removed in favor of duration-based names above.
-		"timeout_ms": func(c *Cfg, v string) error {
+func table(name, desc string, t cfgTable) CfgKey {
+	return CfgKey{Name: name, Desc: desc, Type: "table", set: func(c *Cfg, v string) error {
+		if v != "" {
+			return fmt.Errorf("%s is a table: set its keys, or %s= to remove it", name, name)
+		}
+		t.rm(c)
+		return nil
+	}}
+}
+
+// parseBoolOpt reads a boolean -X value; empty is false, which unsets.
+func parseBoolOpt(v string) (bool, error) {
+	if v == "" {
+		return false, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid boolean %q", v)
+	}
+	return b, nil
+}
+
+func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, suffix string) []CfgKey {
+	return []CfgKey{
+		table(prefix, "The TLS table. "+prefix+"= removes it, turning TLS off"+suffix+".", t),
+		str(prefix+".ca_cert_path", "PEM file holding the CA that signed the server certificates"+suffix+".", t, func(c *Cfg) *string { return &tls(c).CACert }),
+		str(prefix+".client_cert_path", "PEM client certificate, for mutual TLS"+suffix+".", t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
+		str(prefix+".client_key_path", "PEM client key, for mutual TLS"+suffix+".", t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
+		str(prefix+".server_name", "Name to verify the server certificate against, when it is not the host dialed"+suffix+".", t, func(c *Cfg) *string { return &tls(c).ServerName }),
+		boolean(prefix+".insecure", "Skip certificate verification"+suffix+".", t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
+		str(prefix+".min_version", "Lowest TLS version accepted: 1.0, 1.1, 1.2, or 1.3. Default 1.2"+suffix+".", t, func(c *Cfg) *string { return &tls(c).MinVersion }),
+		list(prefix+".cipher_suites", "Cipher suites allowed, by Go name, comma separated"+suffix+".", t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
+		list(prefix+".curve_preferences", "Curves allowed for key exchange, comma separated"+suffix+".", t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
+	}
+}
+
+// cfgKeys is every -X key, in the order kcl profile keys lists them.
+var cfgKeys = func() []CfgKey {
+	keys := []CfgKey{
+		list("seed_brokers", "Brokers to connect to, host:port, comma separated. Default localhost:9092.", topTable, func(c *Cfg) *[]string { return &c.SeedBrokers }),
+		duration("broker_timeout", "How long the broker may spend on an admin request, sent as the wire TimeoutMs. Default 5s.", func(c *Cfg) **Duration { return &c.BrokerTimeout }),
+		duration("dial_timeout", "Bound on one TCP dial. Unset uses kgo's 10s.", func(c *Cfg) **Duration { return &c.DialTimeout }),
+		duration("retry_timeout", "Bound on a request and its retries. Unset uses kgo's 30s, 45s for group requests.", func(c *Cfg) **Duration { return &c.RetryTimeout }),
+		{Name: "timeout_ms", hidden: true, set: func(*Cfg, string) error {
 			return fmt.Errorf("timeout_ms was renamed to broker_timeout and now takes a Go duration (e.g. -X broker_timeout=5s); please update your config or -X flags")
-		},
-		"use_tls":               func(c *Cfg, _ string) error { mktls(c); return nil },
-		"tls.ca_cert_path":      func(c *Cfg, v string) error { mktls(c); c.TLS.CACert = v; return nil },
-		"tls.client_cert_path":  func(c *Cfg, v string) error { mktls(c); c.TLS.ClientCertPath = v; return nil },
-		"tls.client_key_path":   func(c *Cfg, v string) error { mktls(c); c.TLS.ClientKeyPath = v; return nil },
-		"tls.insecure":          func(c *Cfg, _ string) error { mktls(c); c.TLS.InsecureSkipVerify = true; return nil },
-		"tls.server_name":       func(c *Cfg, v string) error { mktls(c); c.TLS.ServerName = v; return nil },
-		"tls.min_version":       func(c *Cfg, v string) error { mktls(c); c.TLS.MinVersion = v; return nil },
-		"tls.cipher_suites":     func(c *Cfg, v string) error { mktls(c); return intoStrSlice(v, &c.TLS.CipherSuites) },
-		"tls.curve_preferences": func(c *Cfg, v string) error { mktls(c); return intoStrSlice(v, &c.TLS.CurvePreferences) },
-		"sasl.method":           func(c *Cfg, v string) error { mksasl(c); c.SASL.Method = v; return nil },
-		"sasl.zid":              func(c *Cfg, v string) error { mksasl(c); c.SASL.Zid = v; return nil },
-		"sasl.user":             func(c *Cfg, v string) error { mksasl(c); c.SASL.User = v; return nil },
-		"sasl.pass":             func(c *Cfg, v string) error { mksasl(c); c.SASL.Pass = v; return nil },
-		"sasl.is_token":         func(c *Cfg, _ string) error { mksasl(c); c.SASL.IsToken = true; return nil }, // accepts any val
-
-		"registry.urls":                  func(c *Cfg, v string) error { mksr(c); return intoStrSlice(v, &c.SR.URLs) },
-		"registry.user":                  func(c *Cfg, v string) error { mksr(c); c.SR.User = v; return nil },
-		"registry.pass":                  func(c *Cfg, v string) error { mksr(c); c.SR.Pass = v; return nil },
-		"registry.bearer_token":          func(c *Cfg, v string) error { mksr(c); c.SR.BearerToken = v; return nil },
-		"registry.context":               func(c *Cfg, v string) error { mksr(c); c.SR.Context = v; return nil },
-		"registry.tls.ca_cert_path":      func(c *Cfg, v string) error { mksrtls(c); c.SR.TLS.CACert = v; return nil },
-		"registry.tls.client_cert_path":  func(c *Cfg, v string) error { mksrtls(c); c.SR.TLS.ClientCertPath = v; return nil },
-		"registry.tls.client_key_path":   func(c *Cfg, v string) error { mksrtls(c); c.SR.TLS.ClientKeyPath = v; return nil },
-		"registry.tls.insecure":          func(c *Cfg, _ string) error { mksrtls(c); c.SR.TLS.InsecureSkipVerify = true; return nil },
-		"registry.tls.server_name":       func(c *Cfg, v string) error { mksrtls(c); c.SR.TLS.ServerName = v; return nil },
-		"registry.tls.min_version":       func(c *Cfg, v string) error { mksrtls(c); c.SR.TLS.MinVersion = v; return nil },
-		"registry.tls.cipher_suites":     func(c *Cfg, v string) error { mksrtls(c); return intoStrSlice(v, &c.SR.TLS.CipherSuites) },
-		"registry.tls.curve_preferences": func(c *Cfg, v string) error { mksrtls(c); return intoStrSlice(v, &c.SR.TLS.CurvePreferences) },
+		}},
+		{Name: "use_tls", Type: "bool", Desc: "true turns TLS on with the system roots; false removes the tls table.", set: func(c *Cfg, v string) error {
+			b, err := parseBoolOpt(v)
+			if err != nil {
+				return err
+			}
+			if b {
+				tlsTable.mk(c)
+			} else {
+				tlsTable.rm(c)
+			}
+			return nil
+		}},
 	}
-
-	// The canonical keys above are dot-separated by field. We index by the
-	// flattened (dot->underscore) form so that both the dotted form and the
-	// legacy pure-underscore form (e.g. "sasl_user") resolve to the same
-	// handler. See normCfgKey.
-	flat := make(map[string]func(*Cfg, string) error, len(fns))
-	for k, fn := range fns {
-		flat[normCfgKey(k)] = fn
-	}
-	return flat
+	keys = append(keys, tlsKeys("tls", tlsTable, func(c *Cfg) *CfgTLS { return c.TLS }, "")...)
+	keys = append(keys,
+		table("sasl", "The SASL table. sasl= removes it.", saslTable),
+		str("sasl.method", "plain, scram-sha-256, scram-sha-512, or aws_msk_iam.", saslTable, func(c *Cfg) *string { return &c.SASL.Method }),
+		str("sasl.zid", "Authorization id, when it differs from the user.", saslTable, func(c *Cfg) *string { return &c.SASL.Zid }),
+		str("sasl.user", "User name.", saslTable, func(c *Cfg) *string { return &c.SASL.User }),
+		str("sasl.pass", "Password.", saslTable, func(c *Cfg) *string { return &c.SASL.Pass }),
+		boolean("sasl.is_token", "The password is a delegation token.", saslTable, func(c *Cfg) *bool { return &c.SASL.IsToken }),
+		table("registry", "The schema registry table. registry= removes it.", srTable),
+		list("registry.urls", "Schema registry URLs, comma separated. Default http://localhost:8081.", srTable, func(c *Cfg) *[]string { return &c.SR.URLs }),
+		str("registry.user", "Basic auth user name.", srTable, func(c *Cfg) *string { return &c.SR.User }),
+		str("registry.pass", "Basic auth password.", srTable, func(c *Cfg) *string { return &c.SR.Pass }),
+		str("registry.bearer_token", "Bearer token, in place of basic auth.", srTable, func(c *Cfg) *string { return &c.SR.BearerToken }),
+		str("registry.context", "Registry context that scopes every request.", srTable, func(c *Cfg) *string { return &c.SR.Context }),
+	)
+	keys = append(keys, tlsKeys("registry.tls", srTLSTable, func(c *Cfg) *CfgTLS { return c.SR.TLS }, " for the registry")...)
+	return keys
 }()
 
-// ApplyCfgOpts applies key=value pairs to cfg in order, using the same keys
-// as -X. The first bad pair stops it with an error.
+// cfgSetters indexes cfgKeys by the flattened (dot->underscore) name, so
+// both the dotted form and the legacy pure-underscore form (e.g.
+// "sasl_user") resolve to the same key. See normCfgKey.
+var cfgSetters = func() map[string]CfgKey {
+	m := make(map[string]CfgKey, len(cfgKeys))
+	for _, k := range cfgKeys {
+		m[normCfgKey(k.Name)] = k
+	}
+	return m
+}()
+
+// ApplyCfgOpts applies -X style options to cfg in order. Each is KEY=VALUE,
+// an empty VALUE unsets the key, and a boolean key may be given bare. The
+// first bad option stops it with an error.
 func ApplyCfgOpts(cfg *Cfg, opts []string) error {
 	for _, opt := range opts {
-		k, v, ok := strings.Cut(opt, "=")
-		if !ok {
-			return fmt.Errorf("opt %q not a key=value", opt)
-		}
-		fn, exists := cfgSetters[normCfgKey(k)]
+		k, v, hasEq := strings.Cut(opt, "=")
+		key, exists := cfgSetters[normCfgKey(k)]
 		if !exists {
-			return fmt.Errorf("unknown opt key %q", k)
+			return fmt.Errorf("unknown opt key %q; kcl profile keys lists them", k)
 		}
-		if err := fn(cfg, v); err != nil {
+		if !hasEq {
+			if key.Type != "bool" {
+				return fmt.Errorf("%s needs a value; %s= unsets it", k, k)
+			}
+			v = "true"
+		}
+		if err := key.set(cfg, v); err != nil {
 			return err
 		}
 	}
@@ -605,7 +747,10 @@ func (c *Client) processOverrides() {
 	// Environment variables use the flattened (underscore) form, uppercased,
 	// since env var names cannot contain dots: KCL_REGISTRY_TLS_SERVER_NAME.
 	var envOverrides []string
-	for k := range cfgSetters {
+	for k, key := range cfgSetters {
+		if key.Type == "table" {
+			continue
+		}
 		if v, exists := os.LookupEnv(c.envPfx + strings.ToUpper(k)); exists {
 			envOverrides = append(envOverrides, k+"="+v)
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -555,12 +555,12 @@ as underscores (KCL_SASL_USER), and from the config file, where a profile is a
 [profiles.NAME] table. Flags win over the environment, which wins over the
 file, which wins over the defaults; only keys that are set take effect.
 
-An empty value unsets a key (-X sasl.pass=). A bool may be given bare
-(-X tls.insecure). The table keys tls, sasl, registry, and registry.tls take
-only the empty value and remove the whole table. A value may reference an
-environment variable as ${NAME}; $${ is a literal ${. A config file can name
-any environment variable this way, so treat a file you did not write like a
-script.
+A bool given bare is true (-X tls.insecure); =false or an empty value
+(-X sasl.pass=) unsets the key. The table keys tls, sasl, registry, and
+registry.tls take only the empty value and remove the whole table. A value
+may reference an environment variable as ${NAME}; $${ is a literal ${. A
+config file can name any environment variable this way, so treat a file you
+did not write like a script.
 
 -X list prints the keys alone. --format json or awk prints them as data.
 Each key below is shown with an example value.

--- a/client/client.go
+++ b/client/client.go
@@ -549,18 +549,15 @@ func XCompletions() []string {
 	return cs
 }
 
-const xHelpIntro = `-X KEY=VALUE sets one key for this command; repeat it for more. The same
-keys come from the environment as KCL_<KEY> (dots as underscores:
-KCL_SASL_USER) and from the config file. Flags beat the environment, which
-beats the file, which beats the defaults; only set keys take effect.
+const xHelpIntro = `-X KEY=VALUE is a repeatable flag to set config keys. The same keys are read
+from the environment as KCL_<KEY> (where dots are underscores:
+KCL_SASL_USER), and from the config file, which "kcl profile" describes.
 
 A bool given bare is true (-X tls.insecure); =false or an empty value
-(-X sasl.pass=) unsets the key. tls=, sasl=, registry=, and registry.tls=
-remove a whole table. ${NAME} in a value reads the environment; $${ is a
-literal ${. A config file can read any environment variable this way, so
-treat one you did not write like a script.
+(-X sasl.pass=) unsets the key. A value may reference an environment
+variable as ${NAME}.
 
--X list prints the keys alone; --format json or awk prints them as data.
+"-X list" prints all keys and can be used with --format.
 `
 
 const xHelpTimeouts = `TIMEOUTS

--- a/client/client.go
+++ b/client/client.go
@@ -549,35 +549,30 @@ func XCompletions() []string {
 	return cs
 }
 
-const xHelpIntro = `-X KEY=VALUE sets one configuration key for this command and may be
-repeated. The same keys are read from the environment as KCL_<KEY>, with dots
-as underscores (KCL_SASL_USER), and from the config file, where a profile is a
-[profiles.NAME] table. Flags win over the environment, which wins over the
-file, which wins over the defaults; only keys that are set take effect.
+const xHelpIntro = `-X KEY=VALUE sets one key for this command; repeat it for more. The same
+keys come from the environment as KCL_<KEY> (dots as underscores:
+KCL_SASL_USER) and from the config file. Flags beat the environment, which
+beats the file, which beats the defaults; only set keys take effect.
 
 A bool given bare is true (-X tls.insecure); =false or an empty value
-(-X sasl.pass=) unsets the key. The table keys tls, sasl, registry, and
-registry.tls take only the empty value and remove the whole table. A value
-may reference an environment variable as ${NAME}; $${ is a literal ${. A
-config file can name any environment variable this way, so treat a file you
-did not write like a script.
+(-X sasl.pass=) unsets the key. tls=, sasl=, registry=, and registry.tls=
+remove a whole table. ${NAME} in a value reads the environment; $${ is a
+literal ${. A config file can read any environment variable this way, so
+treat one you did not write like a script.
 
--X list prints the keys alone. --format json or awk prints them as data.
-Each key below is shown with an example value.
+-X list prints the keys alone; --format json or awk prints them as data.
 `
 
 const xHelpTimeouts = `TIMEOUTS
 
-dial_timeout is caller side, per TCP dial attempt. retry_timeout is client
-side and gates whether to START a retry; it is not a wall clock budget, so an
-in-flight attempt is not cancelled when it elapses. broker_timeout is sent to
-the broker and enforced there, only on requests that carry a TimeoutMs field.
+dial_timeout bounds one TCP dial. retry_timeout gates whether to start a
+retry; an attempt in flight is not cancelled when it elapses. broker_timeout
+is enforced by the broker, on requests that carry a TimeoutMs field.
 
 Keep dial_timeout <= broker_timeout <= retry_timeout. retry_timeout is only
-consulted when an attempt errors, so a slow but successful reply still
-succeeds and one retry can run to about twice broker_timeout in total. If
-dial_timeout is at or above retry_timeout, one failed dial uses the whole
-retry budget and nothing is retried.
+checked when an attempt errors, so one retry can take about twice
+broker_timeout. If dial_timeout is at or above retry_timeout, one failed
+dial spends the retry budget and nothing is retried.
 `
 
 // XHelp renders the long form of -X help: an intro, every key as
@@ -805,29 +800,29 @@ func parseBoolOpt(v string) (bool, error) {
 func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, who string) []CfgKey {
 	d := func(desc string) string { return who + desc }
 	return []CfgKey{
-		table(prefix, d("The TLS table. Setting any "+prefix+".* key turns TLS on; "+prefix+"= removes the table, turning it off."), t),
-		str(prefix+".ca_cert_path", "/etc/kafka/ca.pem", d("PEM file holding the CA that signed the server certificates. Needed when the CA is not in the system roots."), t, func(c *Cfg) *string { return &tls(c).CACert }),
-		str(prefix+".client_cert_path", "/etc/kafka/client.pem", d("PEM client certificate, for mutual TLS. Set with "+prefix+".client_key_path."), t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
-		str(prefix+".client_key_path", "/etc/kafka/client.key", d("PEM client key, for mutual TLS."), t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
-		str(prefix+".server_name", "kafka.example.com", d("Name to verify the server certificate against, when it is not the host dialed."), t, func(c *Cfg) *string { return &tls(c).ServerName }),
-		boolean(prefix+".insecure", d("Skip certificate verification. The connection is still encrypted, but anyone can sit in the middle of it."), t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
-		str(prefix+".min_version", "1.3", d("Lowest TLS version accepted: 1.0, 1.1, 1.2, or 1.3. Default 1.2."), t, func(c *Cfg) *string { return &tls(c).MinVersion }),
-		list(prefix+".cipher_suites", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", d("Cipher suites allowed, by Go name, comma separated. Default is Go's list."), t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
-		list(prefix+".curve_preferences", "X25519,P256", d("Curves allowed for key exchange, comma separated. Default is Go's list."), t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
+		table(prefix, d("The TLS table; "+prefix+"= turns TLS off."), t),
+		str(prefix+".ca_cert_path", "/etc/kafka/ca.pem", d("CA certificate, PEM."), t, func(c *Cfg) *string { return &tls(c).CACert }),
+		str(prefix+".client_cert_path", "/etc/kafka/client.pem", d("Client certificate, PEM, for mTLS."), t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
+		str(prefix+".client_key_path", "/etc/kafka/client.key", d("Client key, PEM, for mTLS."), t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
+		str(prefix+".server_name", "kafka.example.com", d("Name to verify the certificate against, if not the host dialed."), t, func(c *Cfg) *string { return &tls(c).ServerName }),
+		boolean(prefix+".insecure", d("Skip certificate verification."), t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
+		str(prefix+".min_version", "1.3", d("1.0, 1.1, 1.2, or 1.3. Default 1.2."), t, func(c *Cfg) *string { return &tls(c).MinVersion }),
+		list(prefix+".cipher_suites", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", d("Go cipher suite names, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
+		list(prefix+".curve_preferences", "X25519,P256", d("Curve names, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
 	}
 }
 
 // cfgKeys is every -X key. CfgKeys sorts them for display.
 var cfgKeys = func() []CfgKey {
 	keys := []CfgKey{
-		list("seed_brokers", "host1:9092,host2:9092", "Brokers to connect to, host:port, comma separated. Any one of them is enough to find the rest. Default localhost:9092.", topTable, func(c *Cfg) *[]string { return &c.SeedBrokers }),
-		duration("broker_timeout", "5s", "How long the broker may spend on an admin request such as creating a topic, sent as the wire TimeoutMs. Default 5s.", func(c *Cfg) **Duration { return &c.BrokerTimeout }),
-		duration("dial_timeout", "2s", "Bound on one TCP dial. Unset uses kgo's 10s.", func(c *Cfg) **Duration { return &c.DialTimeout }),
-		duration("retry_timeout", "30s", "Bound on a request and its retries. Unset uses kgo's 30s, 45s for group requests.", func(c *Cfg) **Duration { return &c.RetryTimeout }),
+		list("seed_brokers", "host1:9092,host2:9092", "Brokers, comma separated. Default localhost:9092.", topTable, func(c *Cfg) *[]string { return &c.SeedBrokers }),
+		duration("broker_timeout", "5s", "Wire TimeoutMs on admin requests. Default 5s.", func(c *Cfg) **Duration { return &c.BrokerTimeout }),
+		duration("dial_timeout", "2s", "Bound on one TCP dial. Default 10s.", func(c *Cfg) **Duration { return &c.DialTimeout }),
+		duration("retry_timeout", "30s", "Bound on a request and its retries. Default 30s, 45s for group requests.", func(c *Cfg) **Duration { return &c.RetryTimeout }),
 		{Name: "timeout_ms", hidden: true, set: func(*Cfg, string) error {
 			return fmt.Errorf("timeout_ms was renamed to broker_timeout and now takes a Go duration (e.g. -X broker_timeout=5s); please update your config or -X flags")
 		}},
-		{Name: "use_tls", Example: "true", Type: "bool", Desc: "true turns TLS on with the system roots; false removes the tls table. Setting any tls.* key turns TLS on as well.", set: func(c *Cfg, v string) error {
+		{Name: "use_tls", Example: "true", Type: "bool", Desc: "TLS with the system roots. Any tls.* key implies it.", set: func(c *Cfg, v string) error {
 			b, err := parseBoolOpt(v)
 			if err != nil {
 				return err
@@ -842,18 +837,18 @@ var cfgKeys = func() []CfgKey {
 	}
 	keys = append(keys, tlsKeys("tls", tlsTable, func(c *Cfg) *CfgTLS { return c.TLS }, "")...)
 	keys = append(keys,
-		table("sasl", "The SASL table. sasl= removes it, turning authentication off.", saslTable),
-		str("sasl.method", "scram-sha-256", "plain, scram-sha-256, scram-sha-512, or aws_msk_iam; case and dashes do not matter.", saslTable, func(c *Cfg) *string { return &c.SASL.Method }),
-		str("sasl.zid", "", "Authorization id, when it differs from the user. Rarely needed.", saslTable, func(c *Cfg) *string { return &c.SASL.Zid }),
+		table("sasl", "The SASL table; sasl= turns SASL off.", saslTable),
+		str("sasl.method", "scram-sha-256", "plain, scram-sha-256, scram-sha-512, or aws_msk_iam.", saslTable, func(c *Cfg) *string { return &c.SASL.Method }),
+		str("sasl.zid", "", "Authorization id, if not the user.", saslTable, func(c *Cfg) *string { return &c.SASL.Zid }),
 		str("sasl.user", "alice", "User name.", saslTable, func(c *Cfg) *string { return &c.SASL.User }),
-		str("sasl.pass", "${KAFKA_PASS}", "Password. A reference like ${KAFKA_PASS} reads the environment when kcl starts, so the password need not sit in the file.", saslTable, func(c *Cfg) *string { return &c.SASL.Pass }),
+		str("sasl.pass", "${KAFKA_PASS}", "Password.", saslTable, func(c *Cfg) *string { return &c.SASL.Pass }),
 		boolean("sasl.is_token", "The password is a delegation token.", saslTable, func(c *Cfg) *bool { return &c.SASL.IsToken }),
-		table("registry", "The schema registry table. registry= removes it.", srTable),
-		list("registry.urls", "http://sr1:8081,http://sr2:8081", "Schema registry URLs, comma separated. Default http://localhost:8081.", srTable, func(c *Cfg) *[]string { return &c.SR.URLs }),
+		table("registry", "The schema registry table; registry= removes it.", srTable),
+		list("registry.urls", "http://sr1:8081,http://sr2:8081", "Registry URLs, comma separated. Default http://localhost:8081.", srTable, func(c *Cfg) *[]string { return &c.SR.URLs }),
 		str("registry.user", "alice", "Basic auth user name.", srTable, func(c *Cfg) *string { return &c.SR.User }),
 		str("registry.pass", "${SR_PASS}", "Basic auth password.", srTable, func(c *Cfg) *string { return &c.SR.Pass }),
 		str("registry.bearer_token", "${SR_TOKEN}", "Bearer token, in place of basic auth.", srTable, func(c *Cfg) *string { return &c.SR.BearerToken }),
-		str("registry.context", ".mycontext", "Registry context that scopes every request.", srTable, func(c *Cfg) *string { return &c.SR.Context }),
+		str("registry.context", ".mycontext", "Registry context.", srTable, func(c *Cfg) *string { return &c.SR.Context }),
 	)
 	keys = append(keys, tlsKeys("registry.tls", srTLSTable, func(c *Cfg) *CfgTLS { return c.SR.TLS }, "Registry: ")...)
 	return keys

--- a/client/client.go
+++ b/client/client.go
@@ -643,7 +643,8 @@ func (c *Client) MaybeXHelp() bool {
 	return true
 }
 
-// CfgKeys returns every -X key kcl accepts, in display order.
+// CfgKeys returns every -X key kcl accepts, sorted by name, which keeps a
+// table key directly ahead of its own keys.
 func CfgKeys() []CfgKey {
 	var keys []CfgKey
 	for _, k := range cfgKeys {
@@ -651,6 +652,7 @@ func CfgKeys() []CfgKey {
 			keys = append(keys, k)
 		}
 	}
+	slices.SortFunc(keys, func(a, b CfgKey) int { return strings.Compare(a.Name, b.Name) })
 	return keys
 }
 
@@ -815,7 +817,7 @@ func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, who string) []Cf
 	}
 }
 
-// cfgKeys is every -X key, in the order kcl -X help lists them.
+// cfgKeys is every -X key. CfgKeys sorts them for display.
 var cfgKeys = func() []CfgKey {
 	keys := []CfgKey{
 		list("seed_brokers", "host1:9092,host2:9092", "Brokers to connect to, host:port, comma separated. Any one of them is enough to find the rest. Default localhost:9092.", topTable, func(c *Cfg) *[]string { return &c.SeedBrokers }),

--- a/client/client.go
+++ b/client/client.go
@@ -97,7 +97,20 @@ func (d Duration) MarshalText() ([]byte, error) {
 }
 
 // D returns the underlying time.Duration.
-func (d Duration) D() time.Duration { return time.Duration(d) }
+// D returns the duration, or zero when d is nil, which is what an unset
+// timeout means.
+func (d *Duration) D() time.Duration {
+	if d == nil {
+		return 0
+	}
+	return time.Duration(*d)
+}
+
+// Dur returns d as a *Duration, for the timeout fields of Cfg.
+func Dur(d time.Duration) *Duration {
+	dd := Duration(d)
+	return &dd
+}
 
 // Cfg contains kcl options that can be defined in a file.
 type Cfg struct {
@@ -106,17 +119,18 @@ type Cfg struct {
 	// BrokerTimeout is the wire TimeoutMs value sent to the broker
 	// in admin-style requests (e.g. CreateTopics.TimeoutMs). It
 	// tells the broker how long to wait before giving up on the
-	// server side.
-	BrokerTimeout Duration `toml:"broker_timeout,omitzero"`
+	// server side. The timeouts are pointers so that a key written
+	// as zero is kept apart from a key that is not set at all.
+	BrokerTimeout *Duration `toml:"broker_timeout,omitempty"`
 
 	// DialTimeout bounds how long kgo waits for a single TCP dial.
 	// Zero leaves kgo's default (10s).
-	DialTimeout Duration `toml:"dial_timeout,omitzero"`
+	DialTimeout *Duration `toml:"dial_timeout,omitempty"`
 
 	// RetryTimeout bounds total time for a client request and its
 	// retries. Zero leaves kgo's default (30s for most requests,
 	// 45s for group-session requests).
-	RetryTimeout Duration `toml:"retry_timeout,omitzero"`
+	RetryTimeout *Duration `toml:"retry_timeout,omitempty"`
 
 	TLS  *CfgTLS  `toml:"tls,omitzero"`
 	SASL *CfgSASL `toml:"sasl,omitempty"`
@@ -205,6 +219,15 @@ func SetVersion(v string) {
 	}
 }
 
+// defaultCfg is what kcl runs with when nothing sets a key. The config file,
+// environment, and flags are laid over it.
+func defaultCfg() Cfg {
+	return Cfg{
+		SeedBrokers:   []string{"localhost:9092"},
+		BrokerTimeout: Dur(5 * time.Second),
+	}
+}
+
 // New returns a new Client with the given config and installs some
 // persistent flags and commands to root.
 func New(root *cobra.Command) *Client {
@@ -215,10 +238,7 @@ func New(root *cobra.Command) *Client {
 			// audit logs and metrics.
 			kgo.ClientID("kcl/" + clientVersion),
 		},
-		cfg: Cfg{
-			SeedBrokers:   []string{"localhost:9092"},
-			BrokerTimeout: Duration(5 * time.Second),
-		},
+		cfg: defaultCfg(),
 	}
 
 	cfgDir, err := os.UserConfigDir()
@@ -368,8 +388,15 @@ func (c *Client) parseCfgFile() {
 		return
 	}
 
-	// First try decoding as a context-aware config file.
-	md, err := toml.DecodeFile(c.cfgPath, &c.cfgFile)
+	// Profiles decode as primitives so that the selected one can be laid
+	// over the defaults already in c.cfg: only keys present in the file
+	// change anything, and a key written as zero stays zero.
+	var raw struct {
+		CurrentProfile string                    `toml:"current_profile"`
+		Profiles       map[string]toml.Primitive `toml:"profiles"`
+		Cfg
+	}
+	md, err := toml.DecodeFile(c.cfgPath, &raw)
 	if os.IsNotExist(err) {
 		// A missing file is the same as --no-config-file.
 		return
@@ -377,34 +404,52 @@ func (c *Client) parseCfgFile() {
 	if err != nil {
 		out.Die("unable to decode config file %q: %v", c.cfgPath, err)
 	}
-	// Warn on unknown top-level keys so typos and stale names from
-	// old configs don't get silently dropped. This catches "timeout_ms"
-	// after the rename, "tls_xxx" typos, etc.
+
+	c.cfgFile = CfgFile{CurrentProfile: raw.CurrentProfile, Cfg: raw.Cfg}
+	if len(raw.Profiles) > 0 {
+		c.cfgFile.Profiles = make(map[string]Cfg, len(raw.Profiles))
+	}
+	for name, prim := range raw.Profiles {
+		var p Cfg
+		if err := md.PrimitiveDecode(prim, &p); err != nil {
+			out.Die("unable to decode profile %q in %s: %v", name, c.cfgPath, err)
+		}
+		c.cfgFile.Profiles[name] = p
+	}
+
+	// Warn on unknown keys so typos and stale names from old configs do
+	// not get silently dropped. This catches "timeout_ms" after the
+	// rename, "tls_xxx" typos, etc. Keys inside profiles count as
+	// undecoded until PrimitiveDecode above has seen them.
 	if undecoded := md.Undecoded(); len(undecoded) > 0 {
 		for _, k := range undecoded {
 			fmt.Fprintf(os.Stderr, "kcl: warning: unknown config key %q in %s\n", k, c.cfgPath)
 		}
 	}
 
-	// If the file has named profiles, select the appropriate one.
-	if len(c.cfgFile.Profiles) > 0 {
-		name := c.cfgFile.CurrentProfile
+	if len(raw.Profiles) > 0 {
+		name := raw.CurrentProfile
 		if c.profileName != "" {
 			name = c.profileName
 		}
 		if name == "" {
 			out.Die("config has profiles but no current_profile set; use --profile or set current_profile in config")
 		}
-		p, ok := c.cfgFile.Profiles[name]
+		prim, ok := raw.Profiles[name]
 		if !ok {
 			out.Die("profile %q not found in config file", name)
 		}
-		c.cfg = p
+		if err := md.PrimitiveDecode(prim, &c.cfg); err != nil {
+			out.Die("unable to decode profile %q in %s: %v", name, c.cfgPath, err)
+		}
 		return
 	}
 
-	// No profiles: use the flat config (backward compatible).
-	c.cfg = c.cfgFile.Cfg
+	// No profiles: the flat layout. Decoding the file straight into c.cfg
+	// lays its keys over the defaults the same way.
+	if _, err := toml.DecodeFile(c.cfgPath, &c.cfg); err != nil {
+		out.Die("unable to decode config file %q: %v", c.cfgPath, err)
+	}
 }
 
 // CfgFilePath returns the path to the config file.
@@ -464,12 +509,12 @@ var cfgSetters = func() map[string]func(*Cfg, string) error {
 		}
 	}
 
-	intoDuration := func(v string, dst *Duration) error {
+	intoDuration := func(v string, dst **Duration) error {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			return fmt.Errorf("invalid duration %q: %v", v, err)
 		}
-		*dst = Duration(d)
+		*dst = Dur(d)
 		return nil
 	}
 
@@ -596,10 +641,11 @@ func (c *Client) ApplyFlags(cfg *Cfg) ([]string, error) {
 	return keys, nil
 }
 
-// FlagCfg returns the configuration given by the -X, -B, and -R flags alone.
-// This is what "kcl profile create" saves.
+// FlagCfg returns the defaults with the -X, -B, and -R flags laid over them.
+// This is what "kcl profile create" saves, so a new profile spells out what
+// it runs with.
 func (c *Client) FlagCfg() (Cfg, error) {
-	var cfg Cfg
+	cfg := defaultCfg()
 	if _, err := c.ApplyFlags(&cfg); err != nil {
 		return Cfg{}, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -794,18 +794,17 @@ func parseBoolOpt(v string) (bool, error) {
 	return b, nil
 }
 
-func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, who string) []CfgKey {
-	d := func(desc string) string { return who + desc }
+func tlsKeys(prefix string, t cfgTable, tls func(*Cfg) *CfgTLS, what string) []CfgKey {
 	return []CfgKey{
-		table(prefix, d("The TLS table; "+prefix+"= turns TLS off."), t),
-		str(prefix+".ca_cert_path", "/etc/kafka/ca.pem", d("CA certificate, PEM."), t, func(c *Cfg) *string { return &tls(c).CACert }),
-		str(prefix+".client_cert_path", "/etc/kafka/client.pem", d("Client certificate, PEM, for mTLS."), t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
-		str(prefix+".client_key_path", "/etc/kafka/client.key", d("Client key, PEM, for mTLS."), t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
-		str(prefix+".server_name", "kafka.example.com", d("Name to verify the certificate against, if not the host dialed."), t, func(c *Cfg) *string { return &tls(c).ServerName }),
-		boolean(prefix+".insecure", d("Skip certificate verification."), t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
-		str(prefix+".min_version", "1.3", d("1.0, 1.1, 1.2, or 1.3. Default 1.2."), t, func(c *Cfg) *string { return &tls(c).MinVersion }),
-		list(prefix+".cipher_suites", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", d("Go cipher suite names, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
-		list(prefix+".curve_preferences", "X25519,P256", d("Curve names, comma separated."), t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
+		table(prefix, "Turns "+what+" off (removes every "+prefix+".* key).", t),
+		str(prefix+".ca_cert_path", "/etc/kafka/ca.pem", "CA certificate, PEM.", t, func(c *Cfg) *string { return &tls(c).CACert }),
+		str(prefix+".client_cert_path", "/etc/kafka/client.pem", "Client certificate, PEM, for mTLS.", t, func(c *Cfg) *string { return &tls(c).ClientCertPath }),
+		str(prefix+".client_key_path", "/etc/kafka/client.key", "Client key, PEM, for mTLS.", t, func(c *Cfg) *string { return &tls(c).ClientKeyPath }),
+		str(prefix+".server_name", "kafka.example.com", "Name to verify the certificate against, if not the host dialed.", t, func(c *Cfg) *string { return &tls(c).ServerName }),
+		boolean(prefix+".insecure", "Skip certificate verification.", t, func(c *Cfg) *bool { return &tls(c).InsecureSkipVerify }),
+		str(prefix+".min_version", "1.3", "1.0, 1.1, 1.2, or 1.3. Default 1.2.", t, func(c *Cfg) *string { return &tls(c).MinVersion }),
+		list(prefix+".cipher_suites", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", "Go cipher suite names, comma separated.", t, func(c *Cfg) *[]string { return &tls(c).CipherSuites }),
+		list(prefix+".curve_preferences", "X25519,P256", "Curve names, comma separated.", t, func(c *Cfg) *[]string { return &tls(c).CurvePreferences }),
 	}
 }
 
@@ -832,22 +831,22 @@ var cfgKeys = func() []CfgKey {
 			return nil
 		}},
 	}
-	keys = append(keys, tlsKeys("tls", tlsTable, func(c *Cfg) *CfgTLS { return c.TLS }, "")...)
+	keys = append(keys, tlsKeys("tls", tlsTable, func(c *Cfg) *CfgTLS { return c.TLS }, "TLS")...)
 	keys = append(keys,
-		table("sasl", "The SASL table; sasl= turns SASL off.", saslTable),
+		table("sasl", "Turns SASL off (removes every sasl.* key).", saslTable),
 		str("sasl.method", "scram-sha-256", "plain, scram-sha-256, scram-sha-512, or aws_msk_iam.", saslTable, func(c *Cfg) *string { return &c.SASL.Method }),
 		str("sasl.zid", "", "Authorization id, if not the user.", saslTable, func(c *Cfg) *string { return &c.SASL.Zid }),
 		str("sasl.user", "alice", "User name.", saslTable, func(c *Cfg) *string { return &c.SASL.User }),
 		str("sasl.pass", "${KAFKA_PASS}", "Password.", saslTable, func(c *Cfg) *string { return &c.SASL.Pass }),
 		boolean("sasl.is_token", "The password is a delegation token.", saslTable, func(c *Cfg) *bool { return &c.SASL.IsToken }),
-		table("registry", "The schema registry table; registry= removes it.", srTable),
+		table("registry", "Removes every registry.* key.", srTable),
 		list("registry.urls", "http://sr1:8081,http://sr2:8081", "Registry URLs, comma separated. Default http://localhost:8081.", srTable, func(c *Cfg) *[]string { return &c.SR.URLs }),
 		str("registry.user", "alice", "Basic auth user name.", srTable, func(c *Cfg) *string { return &c.SR.User }),
 		str("registry.pass", "${SR_PASS}", "Basic auth password.", srTable, func(c *Cfg) *string { return &c.SR.Pass }),
 		str("registry.bearer_token", "${SR_TOKEN}", "Bearer token, in place of basic auth.", srTable, func(c *Cfg) *string { return &c.SR.BearerToken }),
 		str("registry.context", ".mycontext", "Registry context.", srTable, func(c *Cfg) *string { return &c.SR.Context }),
 	)
-	keys = append(keys, tlsKeys("registry.tls", srTLSTable, func(c *Cfg) *CfgTLS { return c.SR.TLS }, "Registry: ")...)
+	keys = append(keys, tlsKeys("registry.tls", srTLSTable, func(c *Cfg) *CfgTLS { return c.SR.TLS }, "registry TLS")...)
 	return keys
 }()
 

--- a/client/client.go
+++ b/client/client.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -180,6 +181,7 @@ type Client struct {
 	profileName      string   // --context/-C override
 	cfgFile          CfgFile
 	cfg              Cfg
+	cfgWritten       Cfg // cfg before ${NAME} expansion, for profile dump
 }
 
 // Format returns the output format: "text", "json", or "awk".
@@ -301,10 +303,48 @@ func (c *Client) GroupTransactSession() *kgo.GroupTransactSession {
 	return c.txnSess
 }
 
-// DiskCfg returns the loaded disk configuration.
+// DiskCfg returns the configuration as written, with ${NAME} references
+// unexpanded, so that showing it does not show a secret.
 func (c *Client) DiskCfg() Cfg {
 	c.loadClientOnce()
-	return c.cfg
+	return c.cfgWritten
+}
+
+// clone returns a deep copy of c, so that expanding one does not touch the
+// other.
+func (c Cfg) clone() Cfg {
+	cloneTLS := func(t *CfgTLS) *CfgTLS {
+		if t == nil {
+			return nil
+		}
+		d := *t
+		d.CipherSuites = slices.Clone(t.CipherSuites)
+		d.CurvePreferences = slices.Clone(t.CurvePreferences)
+		return &d
+	}
+	d := c
+	d.SeedBrokers = slices.Clone(c.SeedBrokers)
+	if c.BrokerTimeout != nil {
+		d.BrokerTimeout = Dur(c.BrokerTimeout.D())
+	}
+	if c.DialTimeout != nil {
+		d.DialTimeout = Dur(c.DialTimeout.D())
+	}
+	if c.RetryTimeout != nil {
+		d.RetryTimeout = Dur(c.RetryTimeout.D())
+	}
+	d.TLS = cloneTLS(c.TLS)
+	if c.SASL != nil {
+		sasl := *c.SASL
+		d.SASL = &sasl
+	}
+	if c.SR != nil {
+		sr := *c.SR
+		sr.URLs = slices.Clone(c.SR.URLs)
+		sr.TLS = cloneTLS(c.SR.TLS)
+		d.SR = &sr
+	}
+	return d
 }
 
 // DefaultCfgPath returns the default path that is used to load configs.
@@ -349,6 +389,7 @@ func (c *Client) loadCfg() {
 	c.cfgOnce.Do(func() {
 		c.parseCfgFile()     // loads config file if needed
 		c.processOverrides() // overrides config values just loaded
+		c.cfgWritten = c.cfg.clone()
 		if err := expandEnvRefs(&c.cfg); err != nil {
 			out.Die("%s", err)
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -347,6 +349,9 @@ func (c *Client) loadCfg() {
 	c.cfgOnce.Do(func() {
 		c.parseCfgFile()     // loads config file if needed
 		c.processOverrides() // overrides config values just loaded
+		if err := expandEnvRefs(&c.cfg); err != nil {
+			out.Die("%s", err)
+		}
 	})
 }
 
@@ -727,6 +732,71 @@ func ApplyCfgOpts(cfg *Cfg, opts []string) error {
 		}
 	}
 	return nil
+}
+
+// envRef matches ${NAME}, and the escape $${ for a literal ${.
+var envRef = regexp.MustCompile(`\$\$\{|\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// expandEnvRefs replaces ${NAME} in every string value of cfg with the
+// environment variable NAME, so a config file can point at a secret kept in
+// the environment rather than hold it. A reference to a variable that is not
+// set is an error, since an empty password would only fail later and further
+// away. $${ is a literal ${.
+func expandEnvRefs(cfg *Cfg) error {
+	return expandStrings(reflect.ValueOf(cfg).Elem())
+}
+
+func expandStrings(v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.String:
+		s, err := expandRefs(v.String())
+		if err != nil {
+			return err
+		}
+		v.SetString(s)
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			if err := expandStrings(v.Index(i)); err != nil {
+				return err
+			}
+		}
+	case reflect.Ptr:
+		if !v.IsNil() {
+			return expandStrings(v.Elem())
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).IsExported() {
+				if err := expandStrings(v.Field(i)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func expandRefs(s string) (string, error) {
+	if !strings.Contains(s, "${") {
+		return s, nil
+	}
+	var missing string
+	expanded := envRef.ReplaceAllStringFunc(s, func(m string) string {
+		if m == "$${" {
+			return "${"
+		}
+		name := m[2 : len(m)-1]
+		v, ok := os.LookupEnv(name)
+		if !ok {
+			missing = name
+			return m
+		}
+		return v
+	})
+	if missing != "" {
+		return "", fmt.Errorf("config references ${%s}, which is not set in the environment", missing)
+	}
+	return expanded, nil
 }
 
 // applyShorthandFlags applies -B and -R, which win over any other setting

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -646,3 +646,84 @@ func TestEnvSkipsTableKeys(t *testing.T) {
 		t.Errorf("cfg tls=%+v sasl=%+v", c.cfg.TLS, c.cfg.SASL)
 	}
 }
+
+func TestExpandEnvRefs(t *testing.T) {
+	t.Setenv("KCL_TEST_PASS", "s3cret")
+	t.Setenv("KCL_TEST_HOST", "kafka.internal")
+	for _, test := range []struct {
+		name    string
+		cfg     Cfg
+		want    Cfg
+		wantErr string
+	}{
+		{
+			name: "plain values untouched, including a lone dollar",
+			cfg:  Cfg{SASL: &CfgSASL{Pass: "a$b$$c"}},
+			want: Cfg{SASL: &CfgSASL{Pass: "a$b$$c"}},
+		},
+		{
+			name: "reference in a nested table",
+			cfg:  Cfg{SASL: &CfgSASL{User: "me", Pass: "${KCL_TEST_PASS}"}},
+			want: Cfg{SASL: &CfgSASL{User: "me", Pass: "s3cret"}},
+		},
+		{
+			name: "reference inside a list element and text",
+			cfg:  Cfg{SeedBrokers: []string{"${KCL_TEST_HOST}:9092", "b:9092"}},
+			want: Cfg{SeedBrokers: []string{"kafka.internal:9092", "b:9092"}},
+		},
+		{
+			name: "two references and an escape",
+			cfg:  Cfg{SR: &CfgSR{BearerToken: "${KCL_TEST_PASS}-${KCL_TEST_PASS}", Context: "$${KCL_TEST_PASS}"}},
+			want: Cfg{SR: &CfgSR{BearerToken: "s3cret-s3cret", Context: "${KCL_TEST_PASS}"}},
+		},
+		{
+			name: "registry tls path",
+			cfg:  Cfg{SR: &CfgSR{TLS: &CfgTLS{CACert: "/etc/${KCL_TEST_HOST}/ca.pem"}}},
+			want: Cfg{SR: &CfgSR{TLS: &CfgTLS{CACert: "/etc/kafka.internal/ca.pem"}}},
+		},
+		{
+			name: "not an identifier is left alone",
+			cfg:  Cfg{SASL: &CfgSASL{Pass: "${not-a-name}"}},
+			want: Cfg{SASL: &CfgSASL{Pass: "${not-a-name}"}},
+		},
+		{
+			name:    "missing variable is an error",
+			cfg:     Cfg{SASL: &CfgSASL{Pass: "${KCL_TEST_DEFINITELY_UNSET}"}},
+			wantErr: "${KCL_TEST_DEFINITELY_UNSET}, which is not set",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := test.cfg
+			err := expandEnvRefs(&cfg)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg, test.want) {
+				t.Errorf("got sasl=%+v sr=%+v brokers=%v", cfg.SASL, cfg.SR, cfg.SeedBrokers)
+			}
+		})
+	}
+}
+
+// TestLoadCfgExpandsFileAndFlags pins that references are expanded after
+// the file, environment, and flags are combined, so every source is treated
+// the same way.
+func TestLoadCfgExpandsFileAndFlags(t *testing.T) {
+	t.Setenv("KCL_TEST_PASS", "s3cret")
+	t.Setenv("KCL_TEST_USER", "alice")
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[sasl]\npass = \"${KCL_TEST_PASS}\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := &Client{cfgPath: path, format: "text", envPfx: "KCL_", flagOverrides: []string{"sasl.user=${KCL_TEST_USER}"}, cfg: defaultCfg()}
+	c.loadCfg()
+	if c.cfg.SASL == nil || c.cfg.SASL.Pass != "s3cret" || c.cfg.SASL.User != "alice" {
+		t.Errorf("sasl = %+v", c.cfg.SASL)
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -595,7 +596,7 @@ func TestApplyCfgOptsUnsetAndBools(t *testing.T) {
 		{name: "registry tls removal keeps the registry", start: Cfg{SR: &CfgSR{URLs: []string{"http://sr"}, TLS: &CfgTLS{CACert: "/ca"}}}, opts: []string{"registry.tls="}, want: Cfg{SR: &CfgSR{URLs: []string{"http://sr"}}}},
 		{name: "registry tls key creates both tables", opts: []string{"registry.tls.insecure"}, want: Cfg{SR: &CfgSR{TLS: &CfgTLS{InsecureSkipVerify: true}}}},
 		{name: "bare non-boolean", opts: []string{"sasl.user"}, wantErr: "needs a value; sasl.user= unsets it"},
-		{name: "unknown key points at profile keys", opts: []string{"sasl.usr=me"}, wantErr: "kcl profile keys"},
+		{name: "unknown key points at profile keys", opts: []string{"sasl.usr=me"}, wantErr: "kcl -X help"},
 		{name: "legacy underscore form", opts: []string{"sasl_user=me"}, want: Cfg{SASL: &CfgSASL{User: "me"}}},
 		{name: "renamed timeout_ms still explains itself", opts: []string{"timeout_ms=5000"}, wantErr: "renamed to broker_timeout"},
 	} {
@@ -725,5 +726,73 @@ func TestLoadCfgExpandsFileAndFlags(t *testing.T) {
 	c.loadCfg()
 	if c.cfg.SASL == nil || c.cfg.SASL.Pass != "s3cret" || c.cfg.SASL.User != "alice" {
 		t.Errorf("sasl = %+v", c.cfg.SASL)
+	}
+}
+
+func TestXListAndHelpCoverEveryKey(t *testing.T) {
+	list := XList()
+	help := XHelp()
+	for _, k := range CfgKeys() {
+		line := k.Name + "=" + k.Example
+		if !strings.Contains(list, line+"\n") {
+			t.Errorf("-X list lacks %q", line)
+		}
+		if !strings.Contains(help, "\n"+line+"\n  ") {
+			t.Errorf("-X help lacks %q followed by an indented description", line)
+		}
+	}
+	if strings.Contains(list, "timeout_ms") || strings.Contains(help, "timeout_ms=") {
+		t.Error("the renamed timeout_ms is listed")
+	}
+	if !strings.Contains(list, "sasl=\n") {
+		t.Error("a table key should print as NAME= with nothing after")
+	}
+	for _, line := range strings.Split(help, "\n") {
+		if len(line) > 80 {
+			t.Errorf("help line over 80 columns: %q", line)
+		}
+	}
+	if got := wrap("a bb ccc dddd", 8, "  "); got != "  a bb\n  ccc\n  dddd\n" {
+		t.Errorf("wrap = %q", got)
+	}
+}
+
+func TestMaybeXHelp(t *testing.T) {
+	capture := func(f func() bool) (string, bool) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := os.Stdout
+		os.Stdout = w
+		ok := f()
+		w.Close()
+		os.Stdout = old
+		b, _ := io.ReadAll(r)
+		return string(b), ok
+	}
+	for _, test := range []struct {
+		name   string
+		flags  []string
+		format string
+		want   string // substring of stdout
+		wantOK bool
+	}{
+		{name: "nothing", flags: []string{"sasl.user=me"}, format: "text"},
+		{name: "help", flags: []string{"help"}, format: "text", want: "\nsasl.pass=${KAFKA_PASS}\n  Password.", wantOK: true},
+		{name: "list", flags: []string{"sasl.user=me", "list"}, format: "text", want: "sasl.user=alice\n", wantOK: true},
+		{name: "help as json", flags: []string{"help"}, format: "json", want: `"key": "tls.insecure"`, wantOK: true},
+		{name: "list as awk", flags: []string{"list"}, format: "awk", want: "tls.insecure\tbool\ttrue\t", wantOK: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := &Client{flagOverrides: test.flags, format: test.format}
+			got, ok := capture(c.MaybeXHelp)
+			if ok != test.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, test.wantOK)
+			}
+			if !strings.Contains(got, test.want) {
+				t.Errorf("stdout lacks %q:\n%s", test.want, got)
+			}
+		})
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -748,6 +748,9 @@ func TestXListAndHelpCoverEveryKey(t *testing.T) {
 	if !strings.Contains(list, "sasl=\n") {
 		t.Error("a table key should print as NAME= with nothing after")
 	}
+	if !strings.Contains(help, "(-X sasl.pass=) unsets the key") {
+		t.Error("help does not say how to unset a bool")
+	}
 	keys := CfgKeys()
 	if !slices.IsSortedFunc(keys, func(a, b CfgKey) int { return strings.Compare(a.Name, b.Name) }) {
 		t.Error("keys are not sorted by name")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -796,3 +796,39 @@ func TestMaybeXHelp(t *testing.T) {
 		})
 	}
 }
+
+func TestDiskCfgKeepsReferences(t *testing.T) {
+	t.Setenv("KCL_TEST_PASS", "s3cret")
+	c := &Client{noCfgFile: true, format: "text", envPfx: "KCL_", flagOverrides: []string{"sasl.method=plain", "sasl.pass=${KCL_TEST_PASS}", "seed_brokers=${KCL_TEST_PASS}.example:1"}, cfg: defaultCfg()}
+	c.loadCfg()
+	if c.cfg.SASL.Pass != "s3cret" || c.cfg.SeedBrokers[0] != "s3cret.example:1" {
+		t.Errorf("running cfg not expanded: %+v %v", c.cfg.SASL, c.cfg.SeedBrokers)
+	}
+	if c.cfgWritten.SASL.Pass != "${KCL_TEST_PASS}" || c.cfgWritten.SeedBrokers[0] != "${KCL_TEST_PASS}.example:1" || c.cfgWritten.SASL.Method != "plain" {
+		t.Errorf("written cfg changed: %+v %v", c.cfgWritten.SASL, c.cfgWritten.SeedBrokers)
+	}
+}
+
+func TestCfgCloneIsDeep(t *testing.T) {
+	orig := Cfg{
+		SeedBrokers:   []string{"a:1"},
+		BrokerTimeout: Dur(time.Second),
+		TLS:           &CfgTLS{CACert: "/ca", CipherSuites: []string{"x"}},
+		SASL:          &CfgSASL{User: "u"},
+		SR:            &CfgSR{URLs: []string{"http://sr"}, TLS: &CfgTLS{ServerName: "sr"}},
+	}
+	c := orig.clone()
+	if !reflect.DeepEqual(c, orig) {
+		t.Fatalf("clone differs: %+v vs %+v", c, orig)
+	}
+	c.SeedBrokers[0] = "changed"
+	*c.BrokerTimeout = Duration(2 * time.Second)
+	c.TLS.CACert = "changed"
+	c.TLS.CipherSuites[0] = "changed"
+	c.SASL.User = "changed"
+	c.SR.URLs[0] = "changed"
+	c.SR.TLS.ServerName = "changed"
+	if orig.SeedBrokers[0] != "a:1" || orig.BrokerTimeout.D() != time.Second || orig.TLS.CACert != "/ca" || orig.TLS.CipherSuites[0] != "x" || orig.SASL.User != "u" || orig.SR.URLs[0] != "http://sr" || orig.SR.TLS.ServerName != "sr" {
+		t.Errorf("mutating the clone reached the original: %+v tls=%+v sasl=%+v sr=%+v", orig, orig.TLS, orig.SASL, orig.SR)
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -746,6 +747,13 @@ func TestXListAndHelpCoverEveryKey(t *testing.T) {
 	}
 	if !strings.Contains(list, "sasl=\n") {
 		t.Error("a table key should print as NAME= with nothing after")
+	}
+	keys := CfgKeys()
+	if !slices.IsSortedFunc(keys, func(a, b CfgKey) int { return strings.Compare(a.Name, b.Name) }) {
+		t.Error("keys are not sorted by name")
+	}
+	if i := strings.Index(list, "\nregistry.tls=\n"); i < 0 || !strings.HasPrefix(list[i+len("\nregistry.tls=\n"):], "registry.tls.ca_cert_path=") {
+		t.Error("a table key should directly precede its own keys")
 	}
 	for _, line := range strings.Split(help, "\n") {
 		if len(line) > 80 {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -566,3 +566,83 @@ func TestCfgFileLaysOverDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCfgOptsUnsetAndBools(t *testing.T) {
+	tlsOn := func() Cfg { return Cfg{TLS: &CfgTLS{InsecureSkipVerify: true, CACert: "/ca"}} }
+	sasl := func() Cfg { return Cfg{SASL: &CfgSASL{Method: "plain", User: "u", Pass: "p"}} }
+	for _, test := range []struct {
+		name    string
+		start   Cfg
+		opts    []string
+		want    Cfg
+		wantErr string
+	}{
+		{name: "false does not create the tls table", opts: []string{"tls.insecure=false"}, want: Cfg{}},
+		{name: "false on an existing table", start: tlsOn(), opts: []string{"tls.insecure=false"}, want: Cfg{TLS: &CfgTLS{CACert: "/ca"}}},
+		{name: "bare boolean means true", opts: []string{"tls.insecure"}, want: Cfg{TLS: &CfgTLS{InsecureSkipVerify: true}}},
+		{name: "empty boolean unsets", start: tlsOn(), opts: []string{"tls.insecure="}, want: Cfg{TLS: &CfgTLS{CACert: "/ca"}}},
+		{name: "bad boolean", opts: []string{"tls.insecure=maybe"}, wantErr: "invalid boolean"},
+		{name: "empty string unsets and keeps the table", start: sasl(), opts: []string{"sasl.user="}, want: Cfg{SASL: &CfgSASL{Method: "plain", Pass: "p"}}},
+		{name: "unsetting in an absent table stays absent", opts: []string{"sasl.user="}, want: Cfg{}},
+		{name: "table removal", start: sasl(), opts: []string{"sasl="}, want: Cfg{}},
+		{name: "table with a value", opts: []string{"sasl=x"}, wantErr: "is a table"},
+		{name: "slice unset", start: Cfg{SeedBrokers: []string{"a:1"}}, opts: []string{"seed_brokers="}, want: Cfg{}},
+		{name: "slice with an empty element", opts: []string{"seed_brokers=a,,b"}, wantErr: "invalid empty value"},
+		{name: "duration unset", start: Cfg{BrokerTimeout: Dur(time.Second)}, opts: []string{"broker_timeout="}, want: Cfg{}},
+		{name: "duration zero is set", opts: []string{"broker_timeout=0s"}, want: Cfg{BrokerTimeout: Dur(0)}},
+		{name: "use_tls bare", opts: []string{"use_tls"}, want: Cfg{TLS: &CfgTLS{}}},
+		{name: "use_tls false removes the table", start: tlsOn(), opts: []string{"use_tls=false"}, want: Cfg{}},
+		{name: "registry tls removal keeps the registry", start: Cfg{SR: &CfgSR{URLs: []string{"http://sr"}, TLS: &CfgTLS{CACert: "/ca"}}}, opts: []string{"registry.tls="}, want: Cfg{SR: &CfgSR{URLs: []string{"http://sr"}}}},
+		{name: "registry tls key creates both tables", opts: []string{"registry.tls.insecure"}, want: Cfg{SR: &CfgSR{TLS: &CfgTLS{InsecureSkipVerify: true}}}},
+		{name: "bare non-boolean", opts: []string{"sasl.user"}, wantErr: "needs a value; sasl.user= unsets it"},
+		{name: "unknown key points at profile keys", opts: []string{"sasl.usr=me"}, wantErr: "kcl profile keys"},
+		{name: "legacy underscore form", opts: []string{"sasl_user=me"}, want: Cfg{SASL: &CfgSASL{User: "me"}}},
+		{name: "renamed timeout_ms still explains itself", opts: []string{"timeout_ms=5000"}, wantErr: "renamed to broker_timeout"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := test.start
+			err := ApplyCfgOpts(&cfg, test.opts)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg, test.want) {
+				t.Errorf("got %+v tls=%+v sasl=%+v sr=%+v\nwant %+v", cfg, cfg.TLS, cfg.SASL, cfg.SR, test.want)
+			}
+		})
+	}
+}
+
+func TestCfgKeysDescribed(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, k := range CfgKeys() {
+		if k.Desc == "" {
+			t.Errorf("key %q has no description", k.Name)
+		}
+		if seen[normCfgKey(k.Name)] {
+			t.Errorf("key %q collides with another after normalization", k.Name)
+		}
+		seen[normCfgKey(k.Name)] = true
+	}
+	if !seen["sasl_user"] || !seen["registry_tls_ca_cert_path"] || seen["timeout_ms"] {
+		t.Errorf("unexpected key set: %v", seen)
+	}
+}
+
+// TestEnvSkipsTableKeys pins that KCL_TLS or KCL_SASL in the environment,
+// which would only ever be a mistake, is not read as a table removal.
+func TestEnvSkipsTableKeys(t *testing.T) {
+	t.Setenv("KCL_TLS", "1")
+	t.Setenv("KCL_SASL", "1")
+	t.Setenv("KCL_SASL_USER", "env")
+	c := &Client{envPfx: "KCL_", format: "text", cfg: Cfg{TLS: &CfgTLS{CACert: "/ca"}}}
+	c.processOverrides()
+	if c.cfg.TLS == nil || c.cfg.SASL == nil || c.cfg.SASL.User != "env" {
+		t.Errorf("cfg tls=%+v sasl=%+v", c.cfg.TLS, c.cfg.SASL)
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -83,7 +83,7 @@ broker_timeout = "5s"
 		format:  "text",
 		cfg: Cfg{
 			SeedBrokers:   []string{"default:9092"},
-			BrokerTimeout: Duration(time.Second),
+			BrokerTimeout: Dur(time.Second),
 		},
 	}
 	c.parseCfgFile()
@@ -144,7 +144,7 @@ broker_timeout = "3s"
 		format:  "text",
 		cfg: Cfg{
 			SeedBrokers:   []string{"default:9092"},
-			BrokerTimeout: Duration(time.Second),
+			BrokerTimeout: Dur(time.Second),
 		},
 	}
 	c.parseCfgFile()
@@ -162,7 +162,7 @@ func TestCfgFileNoCfgFile(t *testing.T) {
 		format:    "text",
 		cfg: Cfg{
 			SeedBrokers:   []string{"default:9092"},
-			BrokerTimeout: Duration(5 * time.Second),
+			BrokerTimeout: Dur(5 * time.Second),
 		},
 	}
 	c.parseCfgFile()
@@ -384,38 +384,41 @@ func TestFlagCfg(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "nothing given is a zero cfg",
+			name: "nothing given is the defaults",
+			want: defaultCfg(),
 		},
 		{
 			name:      "bootstrap shorthand",
 			bootstrap: []string{"a:9092", "b:9092"},
-			want:      Cfg{SeedBrokers: []string{"a:9092", "b:9092"}},
+			want:      Cfg{SeedBrokers: []string{"a:9092", "b:9092"}, BrokerTimeout: Dur(5 * time.Second)},
 		},
 		{
 			name:      "bootstrap wins over -X seed_brokers",
 			flags:     []string{"seed_brokers=x:9092"},
 			bootstrap: []string{"a:9092"},
-			want:      Cfg{SeedBrokers: []string{"a:9092"}},
+			want:      Cfg{SeedBrokers: []string{"a:9092"}, BrokerTimeout: Dur(5 * time.Second)},
 		},
 		{
 			name:  "tls and sasl, dotted and legacy underscore",
-			flags: []string{"tls.ca_cert_path=/ca.pem", "sasl.method=scram-sha-256", "sasl_user=alice", "dial_timeout=2s"},
+			flags: []string{"tls.ca_cert_path=/ca.pem", "sasl.method=scram-sha-256", "sasl_user=alice", "dial_timeout=2s", "broker_timeout=1s"},
 			want: Cfg{
-				DialTimeout: Duration(2 * time.Second),
-				TLS:         &CfgTLS{CACert: "/ca.pem"},
-				SASL:        &CfgSASL{Method: "scram-sha-256", User: "alice"},
+				SeedBrokers:   []string{"localhost:9092"},
+				BrokerTimeout: Dur(time.Second),
+				DialTimeout:   Dur(2 * time.Second),
+				TLS:           &CfgTLS{CACert: "/ca.pem"},
+				SASL:          &CfgSASL{Method: "scram-sha-256", User: "alice"},
 			},
 		},
 		{
 			name:     "registry shorthand",
 			registry: []string{"http://sr:8081"},
-			want:     Cfg{SR: &CfgSR{URLs: []string{"http://sr:8081"}}},
+			want:     Cfg{SeedBrokers: []string{"localhost:9092"}, BrokerTimeout: Dur(5 * time.Second), SR: &CfgSR{URLs: []string{"http://sr:8081"}}},
 		},
 		{
 			name:      "environment is ignored",
 			env:       map[string]string{"KCL_SASL_PASS": "secret", "KCL_SEED_BROKERS": "env:9092"},
 			bootstrap: []string{"a:9092"},
-			want:      Cfg{SeedBrokers: []string{"a:9092"}},
+			want:      Cfg{SeedBrokers: []string{"a:9092"}, BrokerTimeout: Dur(5 * time.Second)},
 		},
 		{
 			name:    "unknown key",
@@ -463,7 +466,7 @@ func TestCfgEncodeOmitsZeroDurations(t *testing.T) {
 	err := toml.NewEncoder(&buf).Encode(CfgFile{
 		CurrentProfile: "p",
 		Profiles: map[string]Cfg{
-			"p": {SeedBrokers: []string{"a:9092"}, DialTimeout: Duration(2 * time.Second)},
+			"p": {SeedBrokers: []string{"a:9092"}, DialTimeout: Dur(2 * time.Second)},
 		},
 	})
 	if err != nil {
@@ -481,7 +484,7 @@ func TestApplyFlagsKeysAndPreservation(t *testing.T) {
 		bootstrapServers: []string{"a:9092"},
 		registryURLs:     []string{"http://sr:8081"},
 	}
-	cfg := Cfg{SeedBrokers: []string{"old:9092"}, BrokerTimeout: Duration(10 * time.Second)}
+	cfg := Cfg{SeedBrokers: []string{"old:9092"}, BrokerTimeout: Dur(10 * time.Second)}
 	keys, err := c.ApplyFlags(&cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -494,5 +497,72 @@ func TestApplyFlagsKeysAndPreservation(t *testing.T) {
 	}
 	if keys, err := (&Client{}).ApplyFlags(&Cfg{}); err != nil || len(keys) != 0 {
 		t.Errorf("no flags: keys=%v err=%v", keys, err)
+	}
+}
+
+// TestCfgFileLaysOverDefaults pins that a config file only changes the keys
+// it has: a profile without broker_timeout keeps the 5s default, one written
+// as "0s" is zero, and top level keys do not leak into a selected profile.
+func TestCfgFileLaysOverDefaults(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		file        string
+		profile     string
+		wantBrokers string
+		wantTimeout time.Duration
+	}{
+		{
+			name:        "profile without timeout keeps default",
+			file:        "current_profile = \"p\"\n[profiles.p]\nseed_brokers = [\"p:9092\"]\n",
+			wantBrokers: "p:9092",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:        "profile written as zero is zero",
+			file:        "current_profile = \"p\"\n[profiles.p]\nbroker_timeout = \"0s\"\n",
+			wantBrokers: "localhost:9092",
+			wantTimeout: 0,
+		},
+		{
+			name:        "top level keys do not leak into a profile",
+			file:        "current_profile = \"p\"\nbroker_timeout = \"3s\"\n[profiles.p]\nseed_brokers = [\"p:9092\"]\n",
+			wantBrokers: "p:9092",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:        "flat file without timeout keeps default",
+			file:        "seed_brokers = [\"flat:9092\"]\n",
+			wantBrokers: "flat:9092",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:        "flat file written as zero is zero",
+			file:        "broker_timeout = \"0s\"\n",
+			wantBrokers: "localhost:9092",
+			wantTimeout: 0,
+		},
+		{
+			name:        "-C selects and still lays over defaults",
+			file:        "current_profile = \"a\"\n[profiles.a]\nbroker_timeout = \"1s\"\n[profiles.b]\nseed_brokers = [\"b:9092\"]\n",
+			profile:     "b",
+			wantBrokers: "b:9092",
+			wantTimeout: 5 * time.Second,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(test.file), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			c := &Client{cfgPath: path, format: "text", profileName: test.profile, cfg: defaultCfg()}
+			c.parseCfgFile()
+			c.processOverrides()
+			if len(c.cfg.SeedBrokers) != 1 || c.cfg.SeedBrokers[0] != test.wantBrokers {
+				t.Errorf("seed_brokers = %v, want [%s]", c.cfg.SeedBrokers, test.wantBrokers)
+			}
+			if got := c.cfg.BrokerTimeout.D(); got != test.wantTimeout {
+				t.Errorf("broker_timeout = %v, want %v", got, test.wantTimeout)
+			}
+		})
 	}
 }

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -31,7 +31,6 @@ func Command(cl *client.Client) *cobra.Command {
 		createCommand(cl),
 		setupCommand(cl),
 		setCommand(cl),
-		keysCommand(cl),
 		dumpCommand(cl),
 		renameCommand(cl),
 		deleteCommand(cl),
@@ -56,7 +55,6 @@ func DeprecatedCommand(cl *client.Client) *cobra.Command {
 		createCommand(cl),
 		setupCommand(cl),
 		setCommand(cl),
-		keysCommand(cl),
 		dumpCommand(cl),
 		renameCommand(cl),
 		deleteCommand(cl),
@@ -169,8 +167,8 @@ EXAMPLES:
   kcl profile create sr -B localhost:9092 -R http://localhost:8081
 
 SEE ALSO:
+  kcl -X help          every key, with its meaning
   kcl profile use      switch the current profile
-  kcl profile list     list profiles
   kcl profile dump     show the configuration kcl is running with
 `,
 		Args: cobra.ExactArgs(1),
@@ -218,6 +216,7 @@ EXAMPLES:
   kcl -C prod profile set -X sasl.method=scram-sha-256 -X sasl.user=me -X sasl.pass=secret
 
 SEE ALSO:
+  kcl -X help          every key, with its meaning
   kcl profile create   create a profile from the same flags
   kcl profile dump     show the configuration kcl is running with
 `,
@@ -374,53 +373,6 @@ func createProfile(path, name string, cfg client.Cfg) (bool, error) {
 	return current, nil
 }
 
-func keysCommand(cl *client.Client) *cobra.Command {
-	return &cobra.Command{
-		Use:   "keys",
-		Short: "List every config key with its meaning.",
-		Long: `List every config key with its meaning.
-
-These are the keys that -X, KCL_<KEY> environment variables (dots become
-underscores: KCL_SASL_USER), and the config file all share. A bool may be
-given bare, -X tls.insecure, and an empty value unsets any key, -X sasl.pass=.
-The table keys tls, sasl, registry, and registry.tls take only the empty
-value and remove the whole table. A value may reference an environment
-variable as ${NAME}; $${NAME} is a literal.
-
-TIMEOUTS
-
-  dial_timeout    caller side, per TCP dial attempt.
-  retry_timeout   client side; gates whether to START a retry, not a wall
-                  clock budget, so an in-flight attempt is not cancelled
-                  when it elapses.
-  broker_timeout  sent to the broker and enforced there, only on requests
-                  that carry a TimeoutMs field.
-
-  Keep dial_timeout <= broker_timeout <= retry_timeout. retry_timeout is
-  only consulted when an attempt errors, so a slow but successful reply
-  still succeeds and one retry can run to about twice broker_timeout in
-  total. If dial_timeout is at or above retry_timeout, one failed dial uses
-  the whole retry budget and nothing is retried.
-
-EXAMPLES:
-  kcl profile keys                         # table of keys
-  kcl profile keys --format json           # for scripts
-
-SEE ALSO:
-  kcl profile set      set keys in a profile
-  kcl profile dump     show the configuration kcl is running with
-`,
-		Args: cobra.NoArgs,
-		Run: func(*cobra.Command, []string) {
-			table := out.NewFormattedTable(cl.Format(), "profile.keys", 1, "keys", "KEY", "TYPE", "DESCRIPTION")
-			for _, k := range client.CfgKeys() {
-				table.Row(k.Name, k.Type, k.Desc)
-			}
-			table.Flush()
-		},
-	}
-}
-
 func dumpCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "dump",
@@ -521,8 +473,8 @@ PRIORITY (highest wins)
   4. Built-in defaults
 
 Only keys that are set take effect at each level; a key written as zero is
-zero. "kcl profile keys" lists every key, and "kcl profile dump" shows what
-kcl is running with.
+zero. "kcl -X help" describes every key and "kcl -X list" names them;
+"kcl profile dump" shows the result.
 
 EXAMPLES:
   kcl profile create prod -B k1:9092,k2:9092 -X sasl.method=scram-sha-256 -X sasl.user=me -X sasl.pass='${KAFKA_PASS}'

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -207,9 +207,8 @@ func setCommand(cl *client.Client) *cobra.Command {
 		Long: `Set keys in a profile from the -B, -X, and -R flags.
 
 The current profile is changed unless -C names another; a config without
-profiles is edited at the top level. The flags are the ones create builds a
-profile from, so anything that works as a one-off override can be saved.
-Nothing is written unless every flag parses.
+profiles is edited at the top level. Nothing is written unless every flag
+parses.
 
 EXAMPLES:
   kcl profile set -B k1:9092,k2:9092
@@ -472,9 +471,8 @@ PRIORITY (highest wins)
   3. The profile, or the top level keys of a file without profiles
   4. Built-in defaults
 
-Only keys that are set take effect at each level; a key written as zero is
-zero. "kcl -X help" describes every key and "kcl -X list" names them;
-"kcl profile dump" shows the result.
+Only set keys take effect. "kcl -X help" describes every key; "kcl profile
+dump" shows the result.
 
 EXAMPLES:
   kcl profile create prod -B k1:9092,k2:9092 -X sasl.method=scram-sha-256 -X sasl.user=me -X sasl.pass='${KAFKA_PASS}'

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -187,7 +187,7 @@ SEE ALSO:
 			if current {
 				fmt.Fprintf(os.Stderr, "Created profile %q in %s; it is now current\n", name, cfgPath)
 			} else {
-				fmt.Fprintf(os.Stderr, "Created profile %q in %s; switch with: kcl profile use %s\n", name, cfgPath, name)
+				fmt.Fprintf(os.Stderr, "Created profile %q in %s; switch with: kcl profile use %s\n", name, cfgPath, shellWord(name))
 			}
 			return nil
 		},
@@ -237,7 +237,7 @@ SEE ALSO:
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "Set %s in %s\n", strings.Join(keys, ", "), where)
+			fmt.Fprintf(os.Stderr, "Set %s in %s\n", strings.Join(uniq(keys), ", "), where)
 			return nil
 		},
 	}
@@ -291,6 +291,30 @@ func setProfile(path, name string, apply func(*client.Cfg) error) (string, error
 		return "", err
 	}
 	return fmt.Sprintf("profile %q", name), nil
+}
+
+// uniq drops repeated strings, keeping first positions.
+func uniq(ss []string) []string {
+	seen := make(map[string]bool, len(ss))
+	var out []string
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// shellWord quotes s for pasting into a shell when it needs it.
+func shellWord(s string) string {
+	for _, r := range s {
+		plain := r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || strings.ContainsRune("_-./:@+=", r)
+		if !plain {
+			return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+		}
+	}
+	return s
 }
 
 // isFlat reports whether a decoded config uses the flat single cluster

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -20,7 +20,7 @@ import (
 func Command(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "profile",
-		Short: "Manage connection profiles (use, list, create, set, dump, rename, delete).",
+		Short: "Manage connection profiles.",
 		Long:  configHelpText(cl),
 	}
 
@@ -31,6 +31,7 @@ func Command(cl *client.Client) *cobra.Command {
 		createCommand(cl),
 		setupCommand(cl),
 		setCommand(cl),
+		keysCommand(cl),
 		dumpCommand(cl),
 		renameCommand(cl),
 		deleteCommand(cl),
@@ -55,6 +56,7 @@ func DeprecatedCommand(cl *client.Client) *cobra.Command {
 		createCommand(cl),
 		setupCommand(cl),
 		setCommand(cl),
+		keysCommand(cl),
 		dumpCommand(cl),
 		renameCommand(cl),
 		deleteCommand(cl),
@@ -348,6 +350,53 @@ func createProfile(path, name string, cfg client.Cfg) (bool, error) {
 	return current, nil
 }
 
+func keysCommand(cl *client.Client) *cobra.Command {
+	return &cobra.Command{
+		Use:   "keys",
+		Short: "List every config key with its meaning.",
+		Long: `List every config key with its meaning.
+
+These are the keys that -X, KCL_<KEY> environment variables (dots become
+underscores: KCL_SASL_USER), and the config file all share. A bool may be
+given bare, -X tls.insecure, and an empty value unsets any key, -X sasl.pass=.
+The table keys tls, sasl, registry, and registry.tls take only the empty
+value and remove the whole table. A value may reference an environment
+variable as ${NAME}; $${NAME} is a literal.
+
+TIMEOUTS
+
+  dial_timeout    caller side, per TCP dial attempt.
+  retry_timeout   client side; gates whether to START a retry, not a wall
+                  clock budget, so an in-flight attempt is not cancelled
+                  when it elapses.
+  broker_timeout  sent to the broker and enforced there, only on requests
+                  that carry a TimeoutMs field.
+
+  Keep dial_timeout <= broker_timeout <= retry_timeout. retry_timeout is
+  only consulted when an attempt errors, so a slow but successful reply
+  still succeeds and one retry can run to about twice broker_timeout in
+  total. If dial_timeout is at or above retry_timeout, one failed dial uses
+  the whole retry budget and nothing is retried.
+
+EXAMPLES:
+  kcl profile keys                         # table of keys
+  kcl profile keys --format json           # for scripts
+
+SEE ALSO:
+  kcl profile set      set keys in a profile
+  kcl profile dump     show the configuration kcl is running with
+`,
+		Args: cobra.NoArgs,
+		Run: func(*cobra.Command, []string) {
+			table := out.NewFormattedTable(cl.Format(), "profile.keys", 1, "keys", "KEY", "TYPE", "DESCRIPTION")
+			for _, k := range client.CfgKeys() {
+				table.Row(k.Name, k.Type, k.Desc)
+			}
+			table.Flush()
+		},
+	}
+}
+
 func dumpCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "dump",
@@ -429,102 +478,33 @@ func deleteCommand(cl *client.Client) *cobra.Command {
 }
 
 func configHelpText(cl *client.Client) string {
-	return `Manage connection profiles (use, list, create, set, dump, rename, delete).
+	return `Manage connection profiles.
 
-On your machine, kcl takes configuration options by default from:
+Profiles are [profiles.NAME] tables in the config file; current_profile names
+the one in use, and -C picks another for one command. The file is read from:
 
   ` + cl.DefaultCfgPath() + `
 
-The config path can be set with --config-path, while --no-config-file disables
-loading a config file entirely (as well as KCL_NO_CONFIG_FILE being non-empty).
-To show the configuration that kcl is running with, use the dump command.
-
-Three environment variables can be used to override default file path
-semantics: KCL_CONFIG_DIR, KCL_CONFIG_FILE, and KCL_CONFIG_PATH. The first
-changes the directory searched, the middle changes the file name used, and the
-last overrides the former two (as a shortcut for setting both).
-
+--config-path or KCL_CONFIG_PATH move it, --no-config-file or a non-empty
+KCL_NO_CONFIG_FILE skip it, and KCL_CONFIG_DIR and KCL_CONFIG_FILE set the
+directory and file name separately.
 
 PRIORITY (highest wins)
 
-  1. -B/--bootstrap-servers flag       (overrides seed_brokers only)
-  2. -X key=value flags                (repeatable; any config key)
-  3. KCL_<KEY> environment variables   (prefix configurable via --config-env-prefix)
-  4. Active profile ([profiles.NAME])  (selected by --profile/-C or current_profile)
-  5. Top-level config file keys        (flat layout)
-  6. Built-in defaults
+  1. -B, -X, and -R flags
+  2. KCL_<KEY> environment variables, e.g. KCL_SASL_USER
+  3. The profile, or the top level keys of a file without profiles
+  4. Built-in defaults
 
+Only keys that are set take effect at each level; a key written as zero is
+zero. "kcl profile keys" lists every key, and "kcl profile dump" shows what
+kcl is running with.
 
-OPTIONS
-
-Top-level:
-
-  seed_brokers   list of "host:port" strings; default ["localhost:9092"]
-  broker_timeout Go duration sent to the broker in the wire TimeoutMs
-                 field of admin-write requests (CreateTopics, DeleteTopics,
-                 ElectLeaders, WriteTxnMarkers, etc.). Tells the broker how
-                 long it may work on the request before returning
-                 REQUEST_TIMED_OUT. Default 5s.
-  dial_timeout   Go duration bounding a single TCP dial attempt. Zero
-                 uses kgo's default (10s).
-  retry_timeout  Go duration bounding total client request + retries.
-                 Zero uses kgo's default (30s for most requests, 45s
-                 for group-session requests).
-
-Durations accept Go duration strings: "500ms", "5s", "1m", "2m30s".
-
-The [tls] section: ca_cert_path, client_cert_path, client_key_path,
-server_name, min_version, cipher_suites, curve_preferences, insecure.
-
-The [sasl] section: method (plain, scram-sha-256, scram-sha-512,
-aws_msk_iam), zid, user, pass, is_token.
-
-
-TIMEOUT RELATIONSHIP
-
-  dial_timeout   - caller-side, per TCP dial attempt.
-  retry_timeout  - client-side; gates whether to START a retry, NOT a wall
-                   clock budget for the whole operation. An in-flight attempt
-                   is not cancelled when retry_timeout elapses.
-  broker_timeout - sent to broker; enforced server-side, only on requests
-                   that carry a TimeoutMs wire field.
-
-Recommended ordering:
-
-  dial_timeout <= broker_timeout <= retry_timeout
-
-If broker_timeout > retry_timeout, a broker reply that takes the full
-broker_timeout still returns successfully; retry_timeout is only consulted
-if that attempt ERRORS. Worst-case total wall time when a retry fires can
-reach ~2 * broker_timeout (first attempt runs to broker_timeout, errors,
-kgo checks retry_timeout and retries if still within budget, second attempt
-then runs to its own broker_timeout). If dial_timeout >= retry_timeout,
-retries are useless because a single failed dial already consumed the
-retry budget.
-
-
-EXAMPLES
-
-Fast-fail for CI:
-
-  [profiles.cicd]
-  seed_brokers   = ["kafka-staging:9092"]
-  dial_timeout   = "2s"
-  broker_timeout = "5s"
-  retry_timeout  = "5s"
-
-Patient debugging:
-
-  [profiles.debug]
-  seed_brokers   = ["localhost:9092"]
-  broker_timeout = "60s"
-  dial_timeout   = "10s"
-  retry_timeout  = "90s"
-
-One-off overrides:
-
-  kcl -X dial_timeout=2s -B prod:9092 topic list
-  kcl -B host1:9092,host2:9092 topic list   # same as -X seed_brokers=host1:9092,host2:9092
+EXAMPLES:
+  kcl profile create prod -B k1:9092,k2:9092 -X sasl.method=scram-sha-256 -X sasl.user=me -X sasl.pass='${KAFKA_PASS}'
+  kcl -C prod topic list                   # one command against prod
+  kcl profile use prod                     # every command against prod
+  kcl profile set -X dial_timeout=2s       # change the current profile
 `
 }
 

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -376,7 +376,7 @@ func createProfile(path, name string, cfg client.Cfg) (bool, error) {
 func dumpCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "dump",
-		Short: "Dump the loaded configuration",
+		Short: "Dump the loaded configuration, with ${NAME} references as written.",
 		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {
 			toml.NewEncoder(os.Stdout).Encode(cl.DiskCfg())

--- a/commands/myconfig/profile_test.go
+++ b/commands/myconfig/profile_test.go
@@ -2,7 +2,6 @@ package myconfig
 
 import (
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -311,7 +310,6 @@ func TestCreateVisibleSetupHidden(t *testing.T) {
 	}{
 		{"create", false},
 		{"set", false},
-		{"keys", false},
 		{"setup", true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -643,36 +641,6 @@ ca_cert_path = "/ca.pem"
 	got.Profiles["prod"] = prod
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("set changed more than sasl.user:\n got %+v\nwant %+v", got, want)
-	}
-}
-
-func TestKeysCommandLists(t *testing.T) {
-	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
-	cl := client.New(root)
-	root.AddCommand(Command(cl))
-	root.SetArgs([]string{"--format", "awk", "profile", "keys"})
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	old := os.Stdout
-	os.Stdout = w
-	execErr := root.Execute()
-	w.Close()
-	os.Stdout = old
-	outb, _ := io.ReadAll(r)
-	if execErr != nil {
-		t.Fatal(execErr)
-	}
-	got := string(outb)
-	for _, want := range []string{"sasl.user\tstring\t", "tls.insecure\tbool\t", "registry.tls\ttable\t", "broker_timeout\tduration\t", "seed_brokers\tlist\t"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("missing %q in:\n%s", want, got)
-		}
-	}
-	if strings.Contains(got, "timeout_ms") {
-		t.Error("the renamed timeout_ms key is listed")
 	}
 }
 

--- a/commands/myconfig/profile_test.go
+++ b/commands/myconfig/profile_test.go
@@ -446,11 +446,11 @@ seed_brokers = ["s:9092"]
 			wantCode: out.ExitUsage,
 		},
 		{
-			name:     "missing equals",
+			name:     "bare non-boolean key",
 			exists:   true,
 			existing: profiles,
 			opts:     []string{"seed_brokers"},
-			wantErr:  "not a key=value",
+			wantErr:  "needs a value",
 			wantCode: out.ExitUsage,
 		},
 	} {

--- a/commands/myconfig/profile_test.go
+++ b/commands/myconfig/profile_test.go
@@ -675,3 +675,20 @@ func TestKeysCommandLists(t *testing.T) {
 		t.Error("the renamed timeout_ms key is listed")
 	}
 }
+
+func TestShellWordAndUniq(t *testing.T) {
+	for in, want := range map[string]string{
+		"prod":       "prod",
+		"with space": "'with space'",
+		"it's":       `'it'\''s'`,
+		"a/b.c:d":    "a/b.c:d",
+		"a$b":        "'a$b'",
+	} {
+		if got := shellWord(in); got != want {
+			t.Errorf("shellWord(%q) = %s, want %s", in, got, want)
+		}
+	}
+	if got := uniq([]string{"seed_brokers", "sasl.user", "seed_brokers"}); len(got) != 2 || got[0] != "seed_brokers" || got[1] != "sasl.user" {
+		t.Errorf("uniq = %v", got)
+	}
+}

--- a/commands/myconfig/profile_test.go
+++ b/commands/myconfig/profile_test.go
@@ -2,6 +2,7 @@ package myconfig
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -310,6 +311,7 @@ func TestCreateVisibleSetupHidden(t *testing.T) {
 	}{
 		{"create", false},
 		{"set", false},
+		{"keys", false},
 		{"setup", true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -641,5 +643,35 @@ ca_cert_path = "/ca.pem"
 	got.Profiles["prod"] = prod
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("set changed more than sasl.user:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestKeysCommandLists(t *testing.T) {
+	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+	cl := client.New(root)
+	root.AddCommand(Command(cl))
+	root.SetArgs([]string{"--format", "awk", "profile", "keys"})
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	execErr := root.Execute()
+	w.Close()
+	os.Stdout = old
+	outb, _ := io.ReadAll(r)
+	if execErr != nil {
+		t.Fatal(execErr)
+	}
+	got := string(outb)
+	for _, want := range []string{"sasl.user\tstring\t", "tls.insecure\tbool\t", "registry.tls\ttable\t", "broker_timeout\tduration\t", "seed_brokers\tlist\t"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "timeout_ms") {
+		t.Error("the renamed timeout_ms key is listed")
 	}
 }

--- a/commands/myconfig/profile_test.go
+++ b/commands/myconfig/profile_test.go
@@ -42,11 +42,11 @@ func TestWriteAndReadCfgFile(t *testing.T) {
 		Profiles: map[string]client.Cfg{
 			"prod": {
 				SeedBrokers:   []string{"kafka-prod:9092"},
-				BrokerTimeout: client.Duration(10 * time.Second),
+				BrokerTimeout: client.Dur(10 * time.Second),
 			},
 			"local": {
 				SeedBrokers:   []string{"localhost:9092"},
-				BrokerTimeout: client.Duration(5 * time.Second),
+				BrokerTimeout: client.Dur(5 * time.Second),
 			},
 		},
 	}
@@ -228,7 +228,7 @@ seed_brokers = ["p:9092"]
 			profile: "secure",
 			cfg: client.Cfg{
 				SeedBrokers: []string{"k:9093"},
-				DialTimeout: client.Duration(2 * time.Second),
+				DialTimeout: client.Dur(2 * time.Second),
 				TLS:         &client.CfgTLS{CACert: "/ca.pem"},
 				SASL:        &client.CfgSASL{Method: "scram-sha-256", User: "me", Pass: "pw"},
 			},

--- a/main.go
+++ b/main.go
@@ -208,6 +208,20 @@ Command completion is available at:
 	// parsing twice doubled every seed broker.
 	usageErrors(root)
 
+	// -X help and -X list are answered here, after cobra has parsed the flags
+	// so that --format applies. The registry group has a persistent pre-run
+	// of its own, and cobra runs only the nearest one unless told to walk
+	// them all.
+	cobra.EnableTraverseRunHooks = true
+	root.PersistentPreRun = func(*cobra.Command, []string) {
+		if cl.MaybeXHelp() {
+			os.Exit(0)
+		}
+	}
+	root.RegisterFlagCompletionFunc("config-opt", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return client.XCompletions(), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	})
+
 	if wantsHelpJSON(os.Args[1:]) {
 		tree := buildCommandJSON(root, false)
 		enc := json.NewEncoder(os.Stdout)

--- a/main.go
+++ b/main.go
@@ -206,6 +206,8 @@ Command completion is available at:
 	// We look for the flag in the arguments rather than parsing them: Execute
 	// parses again, and slice flags such as -B append on every parse, so
 	// parsing twice doubled every seed broker.
+	usageErrors(root)
+
 	if wantsHelpJSON(os.Args[1:]) {
 		tree := buildCommandJSON(root, false)
 		enc := json.NewEncoder(os.Stdout)
@@ -215,8 +217,38 @@ Command completion is available at:
 	}
 
 	if err := root.Execute(); err != nil {
-		out.HandleError(err, cl.Format())
+		out.HandleError(asUsageError(err), cl.Format())
 	}
+}
+
+// usageErrors wraps every command's argument validator and the flag error
+// handler so that cobra's own errors, a bad argument count or an unknown
+// flag, exit 2 like every other usage error.
+func usageErrors(root *cobra.Command) {
+	allCommands(root, func(cmd *cobra.Command) {
+		validate := cmd.Args
+		if validate == nil {
+			return
+		}
+		cmd.Args = func(c *cobra.Command, args []string) error {
+			if err := validate(c, args); err != nil {
+				return out.Errf(out.ExitUsage, "%v", err)
+			}
+			return nil
+		}
+	})
+	root.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return out.Errf(out.ExitUsage, "%v", err)
+	})
+}
+
+// asUsageError marks cobra's unknown command error, which no hook of ours
+// can produce, as a usage error.
+func asUsageError(err error) error {
+	if err != nil && strings.HasPrefix(err.Error(), "unknown command ") {
+		return out.Errf(out.ExitUsage, "%v", err)
+	}
+	return err
 }
 
 func allCommands(root *cobra.Command, fn func(*cobra.Command)) {

--- a/main.go
+++ b/main.go
@@ -223,9 +223,20 @@ Command completion is available at:
 
 // usageErrors wraps every command's argument validator and the flag error
 // handler so that cobra's own errors, a bad argument count or an unknown
-// flag, exit 2 like every other usage error.
+// flag, exit 2 like every other usage error. A group with no Run of its own
+// gets one that treats a stray argument as an unknown subcommand; cobra
+// itself only reports those at the root, and answered "kcl profile nope"
+// with the help text and exit 0.
 func usageErrors(root *cobra.Command) {
 	allCommands(root, func(cmd *cobra.Command) {
+		if cmd.HasSubCommands() && !cmd.Runnable() {
+			cmd.RunE = func(c *cobra.Command, args []string) error {
+				if len(args) > 0 {
+					return out.Errf(out.ExitUsage, "unknown command %q for %q", args[0], c.CommandPath())
+				}
+				return c.Help()
+			}
+		}
 		validate := cmd.Args
 		if validate == nil {
 			return

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -129,7 +130,7 @@ func TestXCompletionRegistered(t *testing.T) {
 		t.Fatal("no completion registered for -X")
 	}
 	got, _ := f(root, nil, "")
-	if len(got) == 0 || !strings.HasPrefix(got[0], "seed_brokers=\t") {
+	if len(got) == 0 || got[0] != "broker_timeout=\t5s" || !slices.Contains(got, "seed_brokers=\thost1:9092,host2:9092") {
 		t.Errorf("completions = %v", got)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/twmb/kcl/out"
 )
 
 // TestBuildCommandJSONHiddenPropagates pins that --help-json marks a hidden
@@ -66,5 +69,32 @@ func TestWantsHelpJSON(t *testing.T) {
 				t.Errorf("wantsHelpJSON(%q) = %v, want %v", test.args, got, test.want)
 			}
 		})
+	}
+}
+
+func TestUsageErrorsExitTwo(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"argument count", []string{"leaf"}, "accepts 1 arg(s)"},
+		{"unknown flag", []string{"leaf", "x", "--nope"}, "unknown flag"},
+		{"unknown command", []string{"nope"}, "unknown command"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			root.AddCommand(&cobra.Command{Use: "leaf", Args: cobra.ExactArgs(1), Run: func(*cobra.Command, []string) {}})
+			usageErrors(root)
+			root.SetArgs(test.args)
+			err := asUsageError(root.Execute())
+			var ce *out.ExitCodeError
+			if err == nil || !errors.As(err, &ce) || ce.Code != out.ExitUsage || !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("err = %v, want exit %d containing %q", err, out.ExitUsage, test.wantErr)
+			}
+		})
+	}
+	if asUsageError(nil) != nil {
+		t.Error("nil should stay nil")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/twmb/kcl/client"
 	"github.com/twmb/kcl/out"
 )
 
@@ -114,5 +115,21 @@ func TestUsageErrorsExitTwo(t *testing.T) {
 	root.SetArgs([]string{"group"})
 	if err := root.Execute(); err != nil {
 		t.Errorf("bare group: %v", err)
+	}
+}
+
+func TestXCompletionRegistered(t *testing.T) {
+	root := &cobra.Command{Use: "kcl"}
+	root.PersistentFlags().StringArrayP("config-opt", "X", nil, "")
+	root.RegisterFlagCompletionFunc("config-opt", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return client.XCompletions(), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	})
+	f, ok := root.GetFlagCompletionFunc("config-opt")
+	if !ok {
+		t.Fatal("no completion registered for -X")
+	}
+	got, _ := f(root, nil, "")
+	if len(got) == 0 || !strings.HasPrefix(got[0], "seed_brokers=\t") {
+		t.Errorf("completions = %v", got)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -81,10 +82,15 @@ func TestUsageErrorsExitTwo(t *testing.T) {
 		{"argument count", []string{"leaf"}, "accepts 1 arg(s)"},
 		{"unknown flag", []string{"leaf", "x", "--nope"}, "unknown flag"},
 		{"unknown command", []string{"nope"}, "unknown command"},
+		{"unknown subcommand of a group", []string{"group", "nope"}, `unknown command "nope" for "kcl group"`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			root.SetOut(io.Discard)
 			root.AddCommand(&cobra.Command{Use: "leaf", Args: cobra.ExactArgs(1), Run: func(*cobra.Command, []string) {}})
+			group := &cobra.Command{Use: "group"}
+			group.AddCommand(&cobra.Command{Use: "sub", Run: func(*cobra.Command, []string) {}})
+			root.AddCommand(group)
 			usageErrors(root)
 			root.SetArgs(test.args)
 			err := asUsageError(root.Execute())
@@ -96,5 +102,17 @@ func TestUsageErrorsExitTwo(t *testing.T) {
 	}
 	if asUsageError(nil) != nil {
 		t.Error("nil should stay nil")
+	}
+
+	// A bare group still shows its help and succeeds.
+	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+	root.SetOut(io.Discard)
+	group := &cobra.Command{Use: "group"}
+	group.AddCommand(&cobra.Command{Use: "sub", Run: func(*cobra.Command, []string) {}})
+	root.AddCommand(group)
+	usageErrors(root)
+	root.SetArgs([]string{"group"})
+	if err := root.Execute(); err != nil {
+		t.Errorf("bare group: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes from pressure testing the profile commands after #67, plus two design changes: only keys that are set take effect, and `create` starts from the defaults.

**Loader.** Selecting a profile, or loading a flat file, replaced the default config outright. A profile without `broker_timeout` sent `TimeoutMs 0` on every admin request while the help promised 5s, and a profile with no `seed_brokers` made kgo refuse to start, which is what made a flagless `create` fatal. Profiles now decode as toml primitives and are laid over the defaults, so only keys present in the file change anything, and a key written as `"0s"` stays zero. The timeouts are `*Duration` so an explicit zero survives a rewrite; nil is unset. Priority is unchanged: flags, then `KCL_*`, then the file, then defaults.

**Keys.** The setters are now a table with a name, example, description, and type. `kcl -X help` prints an intro, every key as `KEY=EXAMPLE` with its description beneath, sorted by key, and the timeout guidance; `kcl -X list` prints the `KEY=EXAMPLE` lines alone; both honor `--format json` and `awk`. They are answered in a root persistent pre-run after cobra parses flags (run hook traversal is enabled so the registry group's own pre-run does not shadow it), and the same lines feed `-X` tab completion. Booleans parse their value; `-X tls.insecure=false` used to turn verification off. A bool given bare means true. An empty value unsets any key (`-X sasl.pass=`), and `tls=`, `sasl=`, `registry=`, `registry.tls=` remove a whole table. Unsetting a key in a table that does not exist leaves it absent, since an empty `[tls]` table is itself a setting.

**Secrets.** A value may reference an environment variable as `${NAME}`, so `sasl.pass = "${KAFKA_PASS}"` keeps the password out of the file. Expansion runs after file, environment, and flags are combined. A reference to an unset variable is an error rather than an empty password. `$${` is a literal `${`.
`profile dump` shows references as written, so a password kept in the environment does not land in a log that captured dump output.

A config file can name any environment variable, so a file one did not write has to be treated like a script.

**Help.** `kcl profile` printed a hundred lines of timeout reference before the subcommand list and documented TOML section names rather than the `-X` keys `create` and `set` take, with the registry keys missing. It is now the path, the priority order, and examples; the timeout guidance moved to `-X help`.

**Exit codes.** A bad argument count, an unknown flag, and an unknown command exit 2 instead of 1. cobra only reports unknown subcommands at the root, so `kcl profile nope` printed the help and exited 0; groups now get a Run that makes a stray argument an error.

**Small.** Names with spaces are quoted in the "switch with" hint, `set -X seed_brokers=a -B b` no longer reports the key twice, and `--config-path` no longer says "confile".

Tested with unit tests for each piece (overlay cases, 21 unset and boolean cases, env expansion, `-X help` and `-X list` in every format, exit codes for a leaf, a flag, the root, and a group), the race run, and a rerun of the pressure script against the built binary and `kcl fake`.

