### PR TITLE
profile: dump without a client, one usage line, unset wording, current honors -C

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -995,25 +995,28 @@ func (c *Client) processOverrides() {
 }
 
 // ApplyFlags applies the -X, -B, and -R flags to cfg, in that order so the
-// shorthands win, and returns the keys they set. The config file,
-// environment variables, and defaults are not consulted.
-func (c *Client) ApplyFlags(cfg *Cfg) ([]string, error) {
+// shorthands win, and returns the keys they set and the keys they unset. The
+// config file, environment variables, and defaults are not consulted.
+func (c *Client) ApplyFlags(cfg *Cfg) (set, unset []string, err error) {
 	if err := ApplyCfgOpts(cfg, c.flagOverrides); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var keys []string
 	for _, opt := range c.flagOverrides {
-		k, _, _ := strings.Cut(opt, "=")
-		keys = append(keys, k)
+		k, v, hasEq := strings.Cut(opt, "=")
+		if hasEq && v == "" {
+			unset = append(unset, k)
+		} else {
+			set = append(set, k)
+		}
 	}
 	if len(c.bootstrapServers) > 0 {
-		keys = append(keys, "seed_brokers")
+		set = append(set, "seed_brokers")
 	}
 	if len(c.registryURLs) > 0 {
-		keys = append(keys, "registry.urls")
+		set = append(set, "registry.urls")
 	}
 	c.applyShorthandFlags(cfg)
-	return keys, nil
+	return set, unset, nil
 }
 
 // FlagCfg returns the defaults with the -X, -B, and -R flags laid over them.
@@ -1021,7 +1024,7 @@ func (c *Client) ApplyFlags(cfg *Cfg) ([]string, error) {
 // it runs with.
 func (c *Client) FlagCfg() (Cfg, error) {
 	cfg := defaultCfg()
-	if _, err := c.ApplyFlags(&cfg); err != nil {
+	if _, _, err := c.ApplyFlags(&cfg); err != nil {
 		return Cfg{}, err
 	}
 	return cfg, nil

--- a/client/client.go
+++ b/client/client.go
@@ -181,7 +181,8 @@ type Client struct {
 	profileName      string   // --context/-C override
 	cfgFile          CfgFile
 	cfg              Cfg
-	cfgWritten       Cfg // cfg before ${NAME} expansion, for profile dump
+	cfgWritten       Cfg   // cfg before ${NAME} expansion, for profile dump
+	expandErr        error // a bad ${NAME} reference, reported when a client is built
 }
 
 // Format returns the output format: "text", "json", or "awk".
@@ -304,9 +305,11 @@ func (c *Client) GroupTransactSession() *kgo.GroupTransactSession {
 }
 
 // DiskCfg returns the configuration as written, with ${NAME} references
-// unexpanded, so that showing it does not show a secret.
+// unexpanded, so that showing it does not show a secret. It reads the file
+// without building a client, so it works with no broker and with the
+// referenced variables unset.
 func (c *Client) DiskCfg() Cfg {
-	c.loadClientOnce()
+	c.loadCfg()
 	return c.cfgWritten
 }
 
@@ -390,14 +393,21 @@ func (c *Client) loadCfg() {
 		c.parseCfgFile()     // loads config file if needed
 		c.processOverrides() // overrides config values just loaded
 		c.cfgWritten = c.cfg.clone()
-		if err := expandEnvRefs(&c.cfg); err != nil {
-			out.Die("%s", err)
-		}
+		c.expandErr = expandEnvRefs(&c.cfg)
 	})
 }
 
+// loadCfgForClient loads the config and dies on a bad ${NAME} reference,
+// which only matters once something is about to be dialed with the result.
+func (c *Client) loadCfgForClient() {
+	c.loadCfg()
+	if c.expandErr != nil {
+		out.Die("%s", c.expandErr)
+	}
+}
+
 func (c *Client) fillOpts() {
-	c.loadCfg()             // loads config file + overrides (once)
+	c.loadCfgForClient()    // loads config file + overrides (once)
 	c.maybeAddMaxVersions() // fills MaxVersions if necessary
 	c.parseLogLevel()       // adds basic logger if necessary
 
@@ -511,7 +521,7 @@ func (c *Client) ProfileName() string {
 
 // LoadedCfgFile returns the full loaded config file (may include contexts).
 func (c *Client) LoadedCfgFile() CfgFile {
-	c.loadClientOnce()
+	c.loadCfg()
 	return c.cfgFile
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -482,23 +482,26 @@ func TestCfgEncodeOmitsZeroDurations(t *testing.T) {
 
 func TestApplyFlagsKeysAndPreservation(t *testing.T) {
 	c := &Client{
-		flagOverrides:    []string{"sasl.user=me", "sasl_pass=pw"},
+		flagOverrides:    []string{"sasl.user=me", "sasl_pass=pw", "dial_timeout="},
 		bootstrapServers: []string{"a:9092"},
 		registryURLs:     []string{"http://sr:8081"},
 	}
-	cfg := Cfg{SeedBrokers: []string{"old:9092"}, BrokerTimeout: Dur(10 * time.Second)}
-	keys, err := c.ApplyFlags(&cfg)
+	cfg := Cfg{SeedBrokers: []string{"old:9092"}, BrokerTimeout: Dur(10 * time.Second), DialTimeout: Dur(time.Second)}
+	set, unset, err := c.ApplyFlags(&cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := []string{"sasl.user", "sasl_pass", "seed_brokers", "registry.urls"}; !reflect.DeepEqual(keys, want) {
-		t.Errorf("keys = %v, want %v", keys, want)
+	if want := []string{"sasl.user", "sasl_pass", "seed_brokers", "registry.urls"}; !reflect.DeepEqual(set, want) {
+		t.Errorf("set = %v, want %v", set, want)
+	}
+	if want := []string{"dial_timeout"}; !reflect.DeepEqual(unset, want) || cfg.DialTimeout != nil {
+		t.Errorf("unset = %v (dial_timeout=%v), want %v", unset, cfg.DialTimeout, want)
 	}
 	if cfg.BrokerTimeout.D() != 10*time.Second || cfg.SeedBrokers[0] != "a:9092" || cfg.SASL.Pass != "pw" || cfg.SR.URLs[0] != "http://sr:8081" {
 		t.Errorf("cfg = %+v sasl=%+v sr=%+v", cfg, cfg.SASL, cfg.SR)
 	}
-	if keys, err := (&Client{}).ApplyFlags(&Cfg{}); err != nil || len(keys) != 0 {
-		t.Errorf("no flags: keys=%v err=%v", keys, err)
+	if set, unset, err := (&Client{}).ApplyFlags(&Cfg{}); err != nil || len(set)+len(unset) != 0 {
+		t.Errorf("no flags: set=%v unset=%v err=%v", set, unset, err)
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -843,3 +843,18 @@ func TestCfgCloneIsDeep(t *testing.T) {
 		t.Errorf("mutating the clone reached the original: %+v tls=%+v sasl=%+v sr=%+v", orig, orig.TLS, orig.SASL, orig.SR)
 	}
 }
+
+// TestDiskCfgNeedsNoSecrets pins that dump can read a config whose ${NAME}
+// references are unset, and that a client built from it still fails.
+func TestDiskCfgNeedsNoSecrets(t *testing.T) {
+	c := &Client{noCfgFile: true, format: "text", envPfx: "KCL_", flagOverrides: []string{"sasl.method=plain", "sasl.pass=${KCL_TEST_DEFINITELY_UNSET}"}, cfg: defaultCfg()}
+	if got := c.DiskCfg(); got.SASL == nil || got.SASL.Pass != "${KCL_TEST_DEFINITELY_UNSET}" {
+		t.Errorf("DiskCfg = %+v", got.SASL)
+	}
+	if c.expandErr == nil || !strings.Contains(c.expandErr.Error(), "KCL_TEST_DEFINITELY_UNSET") {
+		t.Errorf("expandErr = %v", c.expandErr)
+	}
+	if _, err := c.SchemaRegistryClient(); err == nil || !strings.Contains(err.Error(), "KCL_TEST_DEFINITELY_UNSET") {
+		t.Errorf("registry client err = %v", err)
+	}
+}

--- a/client/sr.go
+++ b/client/sr.go
@@ -21,6 +21,9 @@ const DefaultRegistryURL = "http://localhost:8081"
 // service when they actually need it.
 func (c *Client) SchemaRegistryClient(opts ...sr.ClientOpt) (*sr.Client, error) {
 	c.loadCfg()
+	if c.expandErr != nil {
+		return nil, c.expandErr
+	}
 
 	cfg := c.cfg.SR
 	if cfg == nil {

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -130,7 +130,7 @@ func listCommand(cl *client.Client) *cobra.Command {
 func currentCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "current",
-		Short: "Print the active profile name",
+		Short: "Print the profile in use: the one -C names, else current_profile.",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cfgPath := cl.CfgFilePath()
@@ -140,10 +140,18 @@ func currentCommand(cl *client.Client) *cobra.Command {
 				return fmt.Errorf("unable to read config: %v", err)
 			}
 
-			if cfgFile.CurrentProfile == "" {
+			name := cl.ProfileName()
+			if name != "" {
+				if _, ok := cfgFile.Profiles[name]; !ok {
+					return fmt.Errorf("profile %q not found; available: %v", name, profileNames(cfgFile))
+				}
+			} else {
+				name = cfgFile.CurrentProfile
+			}
+			if name == "" {
 				fmt.Fprintln(os.Stderr, "(no profile set)")
 			} else {
-				fmt.Println(cfgFile.CurrentProfile)
+				fmt.Println(name)
 			}
 			return nil
 		},
@@ -221,13 +229,13 @@ SEE ALSO:
 `,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			var keys []string
+			var set, unset []string
 			where, err := setProfile(cl.CfgFilePath(), cl.ProfileName(), func(cfg *client.Cfg) error {
 				var err error
-				if keys, err = cl.ApplyFlags(cfg); err != nil {
+				if set, unset, err = cl.ApplyFlags(cfg); err != nil {
 					return err
 				}
-				if len(keys) == 0 {
+				if len(set)+len(unset) == 0 {
 					return errors.New("nothing to set; pass -X key=value, -B, or -R")
 				}
 				return nil
@@ -235,7 +243,7 @@ SEE ALSO:
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "Set %s in %s\n", strings.Join(uniq(keys), ", "), where)
+			fmt.Fprintf(os.Stderr, "%s in %s\n", setMessage(set, unset), where)
 			return nil
 		},
 	}
@@ -289,6 +297,18 @@ func setProfile(path, name string, apply func(*client.Cfg) error) (string, error
 		return "", err
 	}
 	return fmt.Sprintf("profile %q", name), nil
+}
+
+// setMessage says what set did: "Set a, b", "Unset c", or "Set a; unset c".
+func setMessage(set, unset []string) string {
+	set, unset = uniq(set), uniq(unset)
+	switch {
+	case len(unset) == 0:
+		return "Set " + strings.Join(set, ", ")
+	case len(set) == 0:
+		return "Unset " + strings.Join(unset, ", ")
+	}
+	return "Set " + strings.Join(set, ", ") + "; unset " + strings.Join(unset, ", ")
 }
 
 // uniq drops repeated strings, keeping first positions.

--- a/commands/myconfig/profile_test.go
+++ b/commands/myconfig/profile_test.go
@@ -2,6 +2,7 @@ package myconfig
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -658,5 +659,67 @@ func TestShellWordAndUniq(t *testing.T) {
 	}
 	if got := uniq([]string{"seed_brokers", "sasl.user", "seed_brokers"}); len(got) != 2 || got[0] != "seed_brokers" || got[1] != "sasl.user" {
 		t.Errorf("uniq = %v", got)
+	}
+}
+
+func TestSetMessage(t *testing.T) {
+	for _, test := range []struct {
+		set, unset []string
+		want       string
+	}{
+		{[]string{"seed_brokers", "seed_brokers"}, nil, "Set seed_brokers"},
+		{nil, []string{"sasl.pass"}, "Unset sasl.pass"},
+		{[]string{"sasl.user"}, []string{"sasl.pass", "dial_timeout"}, "Set sasl.user; unset sasl.pass, dial_timeout"},
+	} {
+		if got := setMessage(test.set, test.unset); got != test.want {
+			t.Errorf("setMessage(%v, %v) = %q, want %q", test.set, test.unset, got, test.want)
+		}
+	}
+}
+
+func TestCurrentHonorsProfileFlag(t *testing.T) {
+	const profiles = "current_profile = \"prod\"\n[profiles.prod]\nseed_brokers = [\"p:9092\"]\n[profiles.dev]\nseed_brokers = [\"d:9092\"]\n"
+	for _, test := range []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr string
+	}{
+		{name: "current_profile", args: []string{"profile", "current"}, want: "prod\n"},
+		{name: "-C wins", args: []string{"-C", "dev", "profile", "current"}, want: "dev\n"},
+		{name: "-C unknown", args: []string{"-C", "nope", "profile", "current"}, wantErr: "not found"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(profiles), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			cl := client.New(root)
+			root.AddCommand(Command(cl))
+			root.SetArgs(append([]string{"--config-path", path}, test.args...))
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			old := os.Stdout
+			os.Stdout = w
+			execErr := root.Execute()
+			w.Close()
+			os.Stdout = old
+			outb, _ := io.ReadAll(r)
+			if test.wantErr != "" {
+				if execErr == nil || !strings.Contains(execErr.Error(), test.wantErr) {
+					t.Fatalf("err = %v, want containing %q", execErr, test.wantErr)
+				}
+				return
+			}
+			if execErr != nil {
+				t.Fatal(execErr)
+			}
+			if string(outb) != test.want {
+				t.Errorf("stdout = %q, want %q", outb, test.want)
+			}
+		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -128,8 +128,8 @@ to provide it.
 For help about configuration, run:
   kcl profile -h
 
-If this is your first time running kcl, you can create a configuration with:
-  kcl profile create
+To create a profile for a cluster:
+  kcl profile create NAME -B host:9092
 
 Command completion is available at:
   kcl misc gen-autocomplete
@@ -206,7 +206,7 @@ Command completion is available at:
 	// We look for the flag in the arguments rather than parsing them: Execute
 	// parses again, and slice flags such as -B append on every parse, so
 	// parsing twice doubled every seed broker.
-	usageErrors(root)
+	usageErrors(root, func() error { _, err := cl.FlagCfg(); return err })
 
 	// -X help and -X list are answered here, after cobra has parsed the flags
 	// so that --format applies. The registry group has a persistent pre-run
@@ -240,13 +240,19 @@ Command completion is available at:
 // flag, exit 2 like every other usage error. A group with no Run of its own
 // gets one that treats a stray argument as an unknown subcommand; cobra
 // itself only reports those at the root, and answered "kcl profile nope"
-// with the help text and exit 0.
-func usageErrors(root *cobra.Command) {
+// with the help text and exit 0. A bare group also runs checkFlags, so that
+// "kcl -X hlep" reports the bad key rather than printing the help.
+func usageErrors(root *cobra.Command, checkFlags func() error) {
 	allCommands(root, func(cmd *cobra.Command) {
 		if cmd.HasSubCommands() && !cmd.Runnable() {
 			cmd.RunE = func(c *cobra.Command, args []string) error {
 				if len(args) > 0 {
 					return out.Errf(out.ExitUsage, "unknown command %q for %q", args[0], c.CommandPath())
+				}
+				if checkFlags != nil {
+					if err := checkFlags(); err != nil {
+						return out.Errf(out.ExitUsage, "%v", err)
+					}
 				}
 				return c.Help()
 			}
@@ -361,7 +367,7 @@ func buildCommandJSON(cmd *cobra.Command, parentHidden bool) commandJSON {
 	return c
 }
 
-const usageTmpl = `USAGE:{{if .Runnable}}
+const usageTmpl = `USAGE:{{if and .Runnable (not .HasAvailableSubCommands)}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 

--- a/main_test.go
+++ b/main_test.go
@@ -93,7 +93,7 @@ func TestUsageErrorsExitTwo(t *testing.T) {
 			group := &cobra.Command{Use: "group"}
 			group.AddCommand(&cobra.Command{Use: "sub", Run: func(*cobra.Command, []string) {}})
 			root.AddCommand(group)
-			usageErrors(root)
+			usageErrors(root, nil)
 			root.SetArgs(test.args)
 			err := asUsageError(root.Execute())
 			var ce *out.ExitCodeError
@@ -106,16 +106,50 @@ func TestUsageErrorsExitTwo(t *testing.T) {
 		t.Error("nil should stay nil")
 	}
 
-	// A bare group still shows its help and succeeds.
-	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
-	root.SetOut(io.Discard)
+	// A bare group still shows its help and succeeds, unless the flag check
+	// fails, which is a usage error.
+	for _, test := range []struct {
+		name    string
+		check   func() error
+		wantErr string
+	}{
+		{name: "help", check: nil},
+		{name: "flags ok", check: func() error { return nil }},
+		{name: "bad -X", check: func() error { return errors.New(`unknown opt key "hlep"`) }, wantErr: "hlep"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			root.SetOut(io.Discard)
+			group := &cobra.Command{Use: "group"}
+			group.AddCommand(&cobra.Command{Use: "sub", Run: func(*cobra.Command, []string) {}})
+			root.AddCommand(group)
+			usageErrors(root, test.check)
+			root.SetArgs([]string{"group"})
+			err := root.Execute()
+			if test.wantErr == "" {
+				if err != nil {
+					t.Errorf("bare group: %v", err)
+				}
+				return
+			}
+			var ce *out.ExitCodeError
+			if err == nil || !errors.As(err, &ce) || ce.Code != out.ExitUsage || !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("err = %v, want exit 2 containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestUsageLineOncePerGroup(t *testing.T) {
+	root := &cobra.Command{Use: "kcl"}
+	root.SetUsageTemplate(usageTmpl)
 	group := &cobra.Command{Use: "group"}
 	group.AddCommand(&cobra.Command{Use: "sub", Run: func(*cobra.Command, []string) {}})
 	root.AddCommand(group)
-	usageErrors(root)
-	root.SetArgs([]string{"group"})
-	if err := root.Execute(); err != nil {
-		t.Errorf("bare group: %v", err)
+	usageErrors(root, nil)
+	got := group.UsageString()
+	if strings.Contains(got, "\n  kcl group\n") || !strings.Contains(got, "\n  kcl group [command]\n") {
+		t.Errorf("usage:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Six fixes from walking the profile commands after #68 merged.

- `profile dump` built a full kgo client to print a file, so it failed with no broker reachable and, once `${NAME}` references existed, whenever a named variable was unset. The load step now records a bad reference and only the client path reports it; dump just reads.
- Giving groups a Run in #68 made cobra print both `kcl profile` and `kcl profile [command]` under USAGE. The template prints the bare line only for commands without subcommands.
- A bare group printed help without looking at `-X`, so `kcl -X hlep` answered with the help text and exit 0. Groups now validate `-X`, `-B`, and `-R` before printing help.
- The root help still said `kcl profile create`, which now needs a name.
- `set -X sasl.pass=` reported "Set sasl.pass". It now says "Unset sasl.pass", and a mixed call says "Set a; unset b".
- `profile current` printed the file's `current_profile` even under `-C`. It now prints the profile in use, and a `-C` naming a missing profile is an error.

Each has a test; the `current` and bare-group cases run through cobra.
