### PR TITLE
commands: one letter per flag, one shape for group topics, add-partitions with -n, --total, -a

### DIFF
--- a/commands/admin/acl/acl.go
+++ b/commands/admin/acl/acl.go
@@ -505,7 +505,7 @@ SEE ALSO:
 	cmd.Flags().BoolVar(&cluster, "cluster", false, "cluster resource")
 	cmd.Flags().StringArrayVar(&operations, "operation", nil, "operation to allow or deny (repeatable)")
 	cmd.Flags().StringVar(&pattern, "pattern", "literal", "resource pattern type: literal or prefixed (Kafka 2.0.0+)")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview ACLs that would be created without creating them")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "preview ACLs that would be created without creating them")
 
 	// Deprecated flags — hidden, still work.
 	cmd.Flags().StringArrayVar(&oldTypes, "type", nil, "")
@@ -766,7 +766,7 @@ For more detailed information about ACLs, read kcl acl --help.
 		"operation":  operationValues,
 		"permission": permissionValues,
 	})
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print ACLs that would be deleted without actually deleting them")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "print ACLs that would be deleted without actually deleting them")
 	cmd.Flags().BoolVarP(&noConfirm, "yes", "y", false, "skip confirmation prompt before deleting")
 
 	// Ergonomic resource-specific flags.

--- a/commands/admin/acl/acl.go
+++ b/commands/admin/acl/acl.go
@@ -18,7 +18,7 @@ import (
 func Command(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "acl",
-		Short: "Perform acl related actions",
+		Short: "Perform acl related actions.",
 		Long: `Perform acl related actions.
 
 ACLs are one of the most undocumented aspects of Kafka.
@@ -156,8 +156,10 @@ func describeCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls", "describe", "d"},
-		Short:   "List ACLs",
-		Long: `List ACLs on a filter basis (Kafka 0.11.0+).
+		Short:   "List ACLs.",
+		Long: `List ACLs.
+
+List ACLs on a filter basis (Kafka 0.11.0+).
 
 Listing ACLs works on a filter basis: anything matching the requested filter
 is returned. For resource names, principals, and hosts, using a wildcard
@@ -307,8 +309,10 @@ func createCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
-		Short:   "Create ACLs",
-		Long: `Create ACLs on a combinatorial basis (Kafka 0.11.0+).
+		Short:   "Create ACLs.",
+		Long: `Create ACLs.
+
+Create ACLs on a combinatorial basis (Kafka 0.11.0+).
 
 ACL creation is combinatorial: all principals x all hosts x all resources x
 all operations. Requires at least one principal, one resource, and one
@@ -541,7 +545,9 @@ func deleteCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete ACLs.",
-		Long: `Delete ACLs on a filter basis (Kafka 0.11.0+).
+		Long: `Delete ACLs.
+
+Delete ACLs on a filter basis (Kafka 0.11.0+).
 
 Like describing, deleting ACLs works on a filter basis: anything matching the
 requested filter is described. Note that for resource names, principals, and

--- a/commands/admin/admin.go
+++ b/commands/admin/admin.go
@@ -66,8 +66,10 @@ func ElectLeadersCommand(cl *client.Client) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "elect-leaders",
-		Short: "Trigger leader elections for partitions",
-		Long: `Trigger leader elections for topic partitions (Kafka 2.2.0+).
+		Short: "Trigger leader elections for partitions.",
+		Long: `Trigger leader elections for partitions.
+
+Trigger leader elections for topic partitions (Kafka 2.2.0+).
 
 This command allows for triggering leader elections on any topic and any
 partition, as well as on all topic partitions. To run on all, you must not

--- a/commands/admin/admin.go
+++ b/commands/admin/admin.go
@@ -4,7 +4,9 @@ package admin
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -87,10 +89,16 @@ Use --dry-run to preview without applying.
 				return fmt.Errorf("unable to parse topic partitions: %v", err)
 			}
 			if dryRun {
-				fmt.Fprintln(os.Stderr, "Dry run: would elect leaders for the following partitions:")
-				for topic, parts := range tps {
-					fmt.Fprintf(os.Stderr, "  %s: %v\n", topic, parts)
+				if cl.Format() == out.FormatText {
+					fmt.Fprintln(os.Stderr, "Dry run: would elect leaders for the following partitions:")
 				}
+				table := out.NewFormattedTable(cl.Format(), "cluster.elect-leaders", 1, "partitions", "TOPIC", "PARTITION")
+				for _, topic := range slices.Sorted(maps.Keys(tps)) {
+					for _, p := range tps[topic] {
+						table.Row(topic, p)
+					}
+				}
+				table.Flush()
 				return nil
 			}
 

--- a/commands/admin/admin.go
+++ b/commands/admin/admin.go
@@ -155,7 +155,7 @@ Use --dry-run to preview without applying.
 
 	cmd.Flags().BoolVar(&allPartitions, "all-partitions", false, "trigger leader election on all topics for all partitions")
 	cmd.Flags().BoolVar(&unclean, "unclean", false, "allow unclean leader election (Kafka 2.4.0+)")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview which partitions would have leaders elected without applying")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "preview which partitions would have leaders elected without applying")
 
 	return cmd
 }

--- a/commands/admin/clientmetrics/clientmetrics.go
+++ b/commands/admin/clientmetrics/clientmetrics.go
@@ -144,7 +144,9 @@ func alterCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "alter NAME",
 		Short: "Create or update a client metrics subscription.",
-		Long: `Create or update a client metrics subscription (KIP-714).
+		Long: `Create or update a client metrics subscription.
+
+See KIP-714.
 
 Common config keys:
   interval.ms            push interval in milliseconds

--- a/commands/admin/clientquotas/client_quotas.go
+++ b/commands/admin/clientquotas/client_quotas.go
@@ -36,7 +36,9 @@ func describeClientQuotas(cl *client.Client) *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"d"},
 		Short:   "Describe client quotas.",
-		Long: `Describe client quotas (Kafka 2.6.0+)
+		Long: `Describe client quotas.
+
+Requires Kafka 2.6.0+.
 
 As mentioned in KIP-546, "by default, quotas are defined in terms of a user and
 client ID, where the user acts as an opaque principal name, and the client ID
@@ -158,7 +160,9 @@ func alterClientQuotas(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "alter",
 		Short: "Alter client quotas.",
-		Long: `Alter client quotas (Kafka 2.6.0+)
+		Long: `Alter client quotas.
+
+Requires Kafka 2.6.0+.
 
 This command alters client quotas; to see a bit more of a description on
 quotas, see the help text for client-quotas or read KIP-546.

--- a/commands/admin/clientquotas/client_quotas.go
+++ b/commands/admin/clientquotas/client_quotas.go
@@ -281,7 +281,7 @@ matches, this runs an alter on anything that matches.
 	cmd.Flags().StringArrayVar(&defaults, "default", nil, "type for default matching, where type is user, client-id, or ip; repeatable")
 	cmd.Flags().StringArrayVar(&adds, "add", nil, "key=value quota to add, where the value is a float64; repeatable")
 	cmd.Flags().StringArrayVar(&deletes, "delete", nil, "key quota to delete; repeatable")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the request without applying changes")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "validate the request without applying changes")
 
 	return cmd
 }

--- a/commands/admin/configs/configs.go
+++ b/commands/admin/configs/configs.go
@@ -72,7 +72,7 @@ func (q *querier) parseEntity(args []string) error {
 	switch q.entity {
 	case entityTopic, entityClientMetrics, entityGroup:
 		if len(args) == 0 {
-			return out.Errf(out.ExitUsage, "missing entity name")
+			return out.Errf(out.ExitUsage, "a name is required for -t %s", q.rawEntity)
 		}
 	}
 	if len(args) > 0 {

--- a/commands/admin/configs/configs.go
+++ b/commands/admin/configs/configs.go
@@ -100,7 +100,9 @@ func alterCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "alter [ENTITY]",
 		Short: "Alter configs (topic, broker, broker logger, client-metrics, group).",
-		Long: `Alter configurations (0.11.0+).
+		Long: `Alter configs (topic, broker, broker logger, client-metrics, group).
+
+Alter configurations (0.11.0+).
 
 Kafka has two modes of altering configurations: wholesale altering, and
 incremental altering. The original altering method requires specifying all
@@ -443,7 +445,9 @@ func describeCommand(cl *client.Client) *cobra.Command {
 		Use:     "describe [ENTITY]",
 		Aliases: []string{"d"},
 		Short:   "Describe configs (topic, broker, broker logger, client-metrics, group).",
-		Long: `Describe configurations (Kafka 0.11.0+).
+		Long: `Describe configs (topic, broker, broker logger, client-metrics, group).
+
+Describe configurations (Kafka 0.11.0+).
 
 This command prints all key/value config values for a given entity. Read only
 keys are suffixed with *.

--- a/commands/admin/dtoken/dtoken.go
+++ b/commands/admin/dtoken/dtoken.go
@@ -20,8 +20,10 @@ import (
 func Command(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dtoken",
-		Short: "Delegation token commands",
-		Long: `Delegation tokens allow for (ideally) a quicker and easier method of enabling
+		Short: "Delegation token commands.",
+		Long: `Delegation token commands.
+
+Delegation tokens allow for (ideally) a quicker and easier method of enabling
 authorization for a wide array of clients. Rather than having to manage many
 accounts external to Kafka, you only need to manage a few accounts and then use
 those accounts to create delegation tokens per client.
@@ -61,8 +63,10 @@ func createTokenCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
-		Short:   "Create a delegation token",
-		Long: `Create a delegation token (Kafka 1.1.0+).
+		Short:   "Create a delegation token.",
+		Long: `Create a delegation token.
+
+Requires Kafka 1.1.0+.
 
 A delegation token inherits all ACLs from the creator. Without any manual
 extra renewers, only the creator can renew.
@@ -123,7 +127,7 @@ func renewTokenCommand(cl *client.Client) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "renew",
-		Short:   "Renew a delegation token (Kafka 1.1.0+)",
+		Short:   "Renew a delegation token (Kafka 1.1.0+).",
 		Example: "renew [base64 hmac here]",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -163,7 +167,7 @@ func expireTokenCommand(cl *client.Client) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "expire",
-		Short:   "Change a delegation token expiry time (Kafka 1.1.0+)",
+		Short:   "Change a delegation token expiry time (Kafka 1.1.0+).",
 		Example: "expire [base64 hmac here]",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -204,7 +208,7 @@ func describeTokensCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"d"},
-		Short:   "Describe delegation tokens (Kafka 1.1.0+)",
+		Short:   "Describe delegation tokens (Kafka 1.1.0+).",
 		Example: ` describe // to display all tokens
 
 describe -o User:admin // to display tokens owned by the admin user`,

--- a/commands/admin/electleaders_test.go
+++ b/commands/admin/electleaders_test.go
@@ -1,0 +1,44 @@
+package admin
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/twmb/kcl/client"
+)
+
+// TestElectLeadersDryRunJSON pins that the dry run is a document on stdout
+// under --format json, not prose on stderr.
+func TestElectLeadersDryRunJSON(t *testing.T) {
+	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+	cl := client.New(root)
+	root.AddCommand(ElectLeadersCommand(cl))
+	root.SetArgs([]string{"--no-config-file", "--format", "json", "elect-leaders", "--dry-run", "foo:1,2", "bar:0"})
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	err := root.Execute()
+	w.Close()
+	os.Stdout = old
+	b, _ := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Command    string `json:"_command"`
+		Partitions []struct {
+			Topic     string `json:"topic"`
+			Partition int32  `json:"partition"`
+		} `json:"partitions"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, b)
+	}
+	if doc.Command != "cluster.elect-leaders" || len(doc.Partitions) != 3 || doc.Partitions[0].Topic != "bar" {
+		t.Errorf("doc = %+v", doc)
+	}
+}

--- a/commands/admin/features/features.go
+++ b/commands/admin/features/features.go
@@ -157,7 +157,7 @@ Use --dry-run to preview without applying.
 		},
 	}
 
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the request without applying changes")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "validate the request without applying changes")
 	cmd.Flags().StringVar(&upgradeType, "upgrade-type", "upgrade", "upgrade | safe-downgrade | unsafe-downgrade")
 	return cmd
 }

--- a/commands/admin/group/describe.go
+++ b/commands/admin/group/describe.go
@@ -30,8 +30,10 @@ func describeCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe GROUPS...",
 		Aliases: []string{"d"},
-		Short:   "Describe consumer groups with lag",
-		Long: `Describe consumer groups with per-partition lag.
+		Short:   "Describe consumer groups with lag.",
+		Long: `Describe consumer groups with lag.
+
+Describe consumer groups with per-partition lag.
 
 By default, text format shows all sections (summary, lag, members). AWK
 format defaults to the lag section. JSON always includes all sections.

--- a/commands/admin/group/describe.go
+++ b/commands/admin/group/describe.go
@@ -113,7 +113,7 @@ SEE ALSO:
 	cmd.Flags().BoolVar(&readCommitted, "committed", false, "use committed (read_committed) offsets for lag computation instead of latest")
 	cmd.Flags().BoolVar(&useConsumerDescribe, "consumer-protocol", false, "use ConsumerGroupDescribe API for new consumer group protocol (KIP-848, Kafka 4.0+)")
 	cmd.Flags().StringVar(&section, "section", "", "output section (summary, lag, members; default: all for text, lag for awk)")
-	cmd.Flags().BoolVar(&regex, "regex", false, "treat group arguments as regular expressions")
+	cmd.Flags().BoolVarP(&regex, "regex", "r", false, "treat group arguments as regular expressions")
 
 	return cmd
 }

--- a/commands/admin/group/describe.go
+++ b/commands/admin/group/describe.go
@@ -95,7 +95,18 @@ SEE ALSO:
 			if err != nil {
 				return err
 			}
-			return printDescribed(cl.Format(), described, fetchedOffsets, listedOffsets, section)
+			if err := printDescribed(cl.Format(), described, fetchedOffsets, listedOffsets, section); err != nil {
+				return err
+			}
+			// A group the broker could not describe, GROUP_ID_NOT_FOUND above
+			// all, is printed with its error and is a failure, as a missing
+			// topic is for topic describe.
+			for _, d := range described {
+				if d.ErrorCode != 0 {
+					return out.ErrSilent
+				}
+			}
+			return nil
 		},
 	}
 
@@ -513,6 +524,11 @@ func describeConsumerGroups(cl *client.Client, groups []string, readCommitted bo
 			if gi < len(results)-1 {
 				fmt.Println()
 			}
+		}
+	}
+	for _, g := range allGroups {
+		if g.group.ErrorCode != 0 {
+			return out.ErrSilent
 		}
 	}
 	return nil

--- a/commands/admin/group/describe_exit_test.go
+++ b/commands/admin/group/describe_exit_test.go
@@ -1,0 +1,62 @@
+package group
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/twmb/kcl/client"
+	"github.com/twmb/kcl/out"
+)
+
+// TestDescribeMissingGroupFails pins that describing a group the broker does
+// not know exits non-zero, as describing a missing topic does, while a group
+// that exists describes cleanly.
+func TestDescribeMissingGroupFails(t *testing.T) {
+	c, err := kfake.NewCluster(kfake.SeedTopics(1, "t"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// Join a group so that one exists.
+	member, err := kgo.NewClient(kgo.SeedBrokers(c.ListenAddrs()...), kgo.ConsumerGroup("g1"), kgo.ConsumeTopics("t"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer member.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	member.PollFetches(ctx)
+	cancel()
+
+	for _, test := range []struct {
+		group   string
+		wantErr error
+	}{
+		{"g1", nil},
+		{"nope", out.ErrSilent},
+	} {
+		t.Run(test.group, func(t *testing.T) {
+			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			cl := client.New(root)
+			root.AddCommand(Command(cl))
+			root.SetArgs([]string{"--no-config-file", "-B", c.ListenAddrs()[0], "-X", "dial_timeout=2s", "-X", "retry_timeout=10s", "group", "describe", test.group})
+			r, w, _ := os.Pipe()
+			old := os.Stdout
+			os.Stdout = w
+			err := root.Execute()
+			w.Close()
+			os.Stdout = old
+			io.ReadAll(r)
+			if err != test.wantErr {
+				t.Fatalf("err = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/commands/admin/group/group.go
+++ b/commands/admin/group/group.go
@@ -43,7 +43,9 @@ func listCommand(cl *client.Client) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List all groups (Kafka 0.9.0+).",
-		Long: `List all Kafka groups.
+		Long: `List all groups (Kafka 0.9.0+).
+
+List all Kafka groups.
 
 This command simply lists groups and their protocol types; it does not describe
 the groups listed. This prints all of the information from a ListGroups request.
@@ -167,7 +169,9 @@ func offsetDeleteCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "offset-delete GROUP",
 		Short: "Delete offsets for a Kafka group.",
-		Long: `Forcefully delete offsets for a Kafka group (Kafka 2.4.0+).
+		Long: `Delete offsets for a Kafka group.
+
+Forcefully delete offsets for a Kafka group (Kafka 2.4.0+).
 
 Introduced in Kafka 2.4.0, this command forcefully deletes committed offsets
 for a group. Why, you ask? Group commit expiration semantics have changed

--- a/commands/admin/group/group.go
+++ b/commands/admin/group/group.go
@@ -157,8 +157,8 @@ func deleteCommand(cl *client.Client) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print groups that would be deleted without actually deleting them")
-	cmd.Flags().BoolVar(&regex, "regex", false, "treat group arguments as regular expressions")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "print groups that would be deleted without actually deleting them")
+	cmd.Flags().BoolVarP(&regex, "regex", "r", false, "treat group arguments as regular expressions")
 	return cmd
 }
 

--- a/commands/admin/group/seek.go
+++ b/commands/admin/group/seek.go
@@ -61,14 +61,14 @@ By default, seeking will only commit offsets for topics already present
 in the group's committed offsets. Use --allow-new-topics to also commit
 offsets for topics not currently in the group.
 
---topics accepts plain names or topic:partitions pairs:
+-t accepts plain names or topic:partitions pairs:
   foo              all partitions of foo
   foo:0,2          only partitions 0 and 2 of foo
 
 EXAMPLES:
   kcl group seek mygroup --to start
-  kcl group seek mygroup --to end --topics foo,bar
-  kcl group seek mygroup --to 100 --topics foo:0,1,2
+  kcl group seek mygroup --to end -t foo,bar
+  kcl group seek mygroup --to 100 -t foo:0,1,2
   kcl group seek mygroup --to @-1h
   kcl group seek mygroup --to @2024-01-15
   kcl group seek mygroup --to +0 --yes
@@ -220,7 +220,7 @@ SEE ALSO:
 					return out.Errf(out.ExitUsage, "--to does not accept range offsets; use a single target value")
 				}
 
-				// Determine target topics: either from --topics flag or from existing commits.
+				// Determine target topics: either from -t flag or from existing commits.
 				var targetTopics []string
 				if len(topicNames) > 0 {
 					targetTopics = topicNames
@@ -234,7 +234,7 @@ SEE ALSO:
 					})
 				}
 				if len(targetTopics) == 0 {
-					return fmt.Errorf("no topics to seek; the group has no committed offsets and --topics was not specified")
+					return fmt.Errorf("no topics to seek; the group has no committed offsets and -t was not specified")
 				}
 
 				keepListed := func(lo kadm.ListedOffset) bool {
@@ -443,8 +443,10 @@ SEE ALSO:
 	cmd.Flags().StringVar(&to, "to", "", "target offset (start, end, +N, -N, N, @timestamp)")
 	cmd.Flags().StringVar(&toGroup, "to-group", "", "seek to another group's committed offsets (mutually exclusive with --to and --to-file)")
 	cmd.Flags().StringVar(&toFile, "to-file", "", "seek to offsets from a JSON file (mutually exclusive with --to and --to-group)")
-	cmd.Flags().StringArrayVar(&topics, "topics", nil, "filter to specific topics; repeatable or comma-separated, entries may be topic:p1,p2")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview offset changes without applying")
+	cmd.Flags().StringArrayVarP(&topics, "topic", "t", nil, "filter to specific topics; repeatable or comma-separated, entries may be topic:p1,p2")
+	cmd.Flags().StringArrayVar(&topics, "topics", nil, "old name of --topic")
+	cmd.Flags().MarkHidden("topics")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "preview offset changes without applying")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "apply changes without interactive confirmation")
 	cmd.Flags().BoolVar(&allowNewTopics, "allow-new-topics", false, "allow committing offsets for topics not in the group's current commits")
 

--- a/commands/admin/group/seek.go
+++ b/commands/admin/group/seek.go
@@ -35,7 +35,9 @@ func seekCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "seek GROUP",
 		Short: "Reset consumer group offsets.",
-		Long: `Reset consumer group offsets (Kafka 0.11.0+).
+		Long: `Reset consumer group offsets.
+
+Requires Kafka 0.11.0+.
 
 Seek adjusts the committed offsets for a consumer group. The group must
 have no active members (state Empty or Dead).

--- a/commands/admin/logdirs/logdirs.go
+++ b/commands/admin/logdirs/logdirs.go
@@ -55,7 +55,9 @@ func describeCommand(cl *client.Client) *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"d"},
 		Short:   "Describe log directories for topic partitions.",
-		Long: `Describe log directories for topic partitions (Kafka 1.0.0+).
+		Long: `Describe log directories for topic partitions.
+
+Requires Kafka 1.0.0+.
 
 Log directories are partition specific. The size of a directory is the absolute
 size of log segments of a partition, in bytes.
@@ -272,8 +274,10 @@ func alterReplicasCommand(cl *client.Client) *cobra.Command {
 	var broker int32
 	cmd := &cobra.Command{
 		Use:   "alter",
-		Short: "Move topic replicas to a destination directory",
-		Long: `Move topic partitions to specified directories (Kafka 1.0.0+).
+		Short: "Move topic replicas to a destination directory.",
+		Long: `Move topic replicas to a destination directory.
+
+Move topic partitions to specified directories (Kafka 1.0.0+).
 
 Introduced in Kafka 1.0.0, this command allows for moving replica log
 directories. See KIP-113 for the motivation.

--- a/commands/admin/logdirs/logdirs.go
+++ b/commands/admin/logdirs/logdirs.go
@@ -291,6 +291,7 @@ which allows you to alter replicas.
 
 		Example: `alter foo:1,2,3=/dir bar:6=/dir2 baz:9=/dir`,
 
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, topics []string) error {
 			dests := make(map[string]map[string][]int32)
 			for _, topic := range topics {

--- a/commands/admin/logdirs/logdirs_args_test.go
+++ b/commands/admin/logdirs/logdirs_args_test.go
@@ -1,0 +1,21 @@
+package logdirs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/twmb/kcl/client"
+)
+
+func TestAlterRequiresArguments(t *testing.T) {
+	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+	cl := client.New(root)
+	root.AddCommand(Command(cl))
+	root.SetArgs([]string{"--no-config-file", "logdirs", "alter"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires at least 1 arg") {
+		t.Fatalf("err = %v, want an argument count error", err)
+	}
+}

--- a/commands/admin/partas/partition_assignments.go
+++ b/commands/admin/partas/partition_assignments.go
@@ -29,7 +29,9 @@ func alterPartitionAssignments(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "alter",
 		Short: "Alter partition assignments.",
-		Long: `Alter which brokers partitions are assigned to (Kafka 2.4.0+).
+		Long: `Alter partition assignments.
+
+Alter which brokers partitions are assigned to (Kafka 2.4.0+).
 
 The syntax for each topic is
 
@@ -104,7 +106,9 @@ func cancelPartitionReassignments(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "cancel",
 		Short: "Cancel in-progress partition reassignments.",
-		Long: `Cancel active partition reassignments (Kafka 2.4.0+).
+		Long: `Cancel in-progress partition reassignments.
+
+Cancel active partition reassignments (Kafka 2.4.0+).
 
 The syntax for each topic is
 
@@ -184,7 +188,9 @@ func listPartitionReassignments(cl *client.Client) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List partition reassignments.",
-		Long: `List which partitions are currently being reassigned (Kafka 2.4.0+).
+		Long: `List partition reassignments.
+
+List which partitions are currently being reassigned (Kafka 2.4.0+).
 
 The syntax for each topic is
 

--- a/commands/admin/sharegroup/offsets.go
+++ b/commands/admin/sharegroup/offsets.go
@@ -14,8 +14,9 @@ import (
 )
 
 func offsetDeleteCommand(cl *client.Client) *cobra.Command {
+	var topicFlags []string
 	cmd := &cobra.Command{
-		Use:   "offset-delete GROUP TOPICS...",
+		Use:   "offset-delete GROUP",
 		Short: "Delete share group offsets for topics (Kafka 4.0+).",
 		Long: `Delete share group offsets for topics (Kafka 4.0+).
 
@@ -24,11 +25,16 @@ Delete share group offsets for topics (KIP-932, Kafka 4.0+).
 The group must be empty (no active consumers). This deletes all offset state
 for the specified topics within the share group.
 `,
-		Example: "offset-delete mygroup foo bar",
-		Args:    cobra.MinimumNArgs(2),
+		Example: "offset-delete mygroup -t foo -t bar",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			group := args[0]
-			topics := args[1:]
+			// Positional topics after the group are the old form, kept
+			// working but out of the help.
+			topics := append(topicFlags, args[1:]...)
+			if len(topics) == 0 {
+				return out.Errf(out.ExitUsage, "at least one topic is required (-t)")
+			}
 
 			req := kmsg.NewPtrDeleteShareGroupOffsetsRequest()
 			req.GroupID = group
@@ -67,5 +73,6 @@ for the specified topics within the share group.
 			return nil
 		},
 	}
+	cmd.Flags().StringArrayVarP(&topicFlags, "topic", "t", nil, "topic to delete offsets for; repeatable")
 	return cmd
 }

--- a/commands/admin/sharegroup/offsets.go
+++ b/commands/admin/sharegroup/offsets.go
@@ -17,7 +17,9 @@ func offsetDeleteCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "offset-delete GROUP TOPICS...",
 		Short: "Delete share group offsets for topics (Kafka 4.0+).",
-		Long: `Delete share group offsets for topics (KIP-932, Kafka 4.0+).
+		Long: `Delete share group offsets for topics (Kafka 4.0+).
+
+Delete share group offsets for topics (KIP-932, Kafka 4.0+).
 
 The group must be empty (no active consumers). This deletes all offset state
 for the specified topics within the share group.

--- a/commands/admin/sharegroup/offsets_args_test.go
+++ b/commands/admin/sharegroup/offsets_args_test.go
@@ -1,0 +1,21 @@
+package sharegroup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/twmb/kcl/client"
+)
+
+func TestOffsetDeleteNeedsTopics(t *testing.T) {
+	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+	cl := client.New(root)
+	root.AddCommand(Command(cl))
+	root.SetArgs([]string{"--no-config-file", "share-group", "offset-delete", "g"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "at least one topic is required (-t)") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/commands/admin/sharegroup/seek.go
+++ b/commands/admin/sharegroup/seek.go
@@ -55,16 +55,16 @@ because share groups have start offsets, not committed offsets.
 The --to-file flag reads target offsets from a JSON file with format:
   [{"topic": "foo", "partition": 0, "offset": 100}, ...]
 
---topics accepts plain names or topic:partitions pairs (matching the
+-t accepts plain names or topic:partitions pairs (matching the
 kafka-share-groups.sh --topic syntax):
   foo              all partitions of foo
   foo:0,2          only partitions 0 and 2 of foo
 
 EXAMPLES:
-  kcl share-group seek mygroup --to start --topics foo,bar
-  kcl share-group seek mygroup --to end --topics foo:0,1,2
-  kcl share-group seek mygroup --to @-1h --topics foo,bar
-  kcl share-group seek mygroup --to 100 --topics foo --dry-run
+  kcl share-group seek mygroup --to start -t foo,bar
+  kcl share-group seek mygroup --to end -t foo:0,1,2
+  kcl share-group seek mygroup --to @-1h -t foo,bar
+  kcl share-group seek mygroup --to 100 -t foo --dry-run
   kcl share-group seek mygroup --to-file offsets.json
 `,
 		Args: cobra.ExactArgs(1),
@@ -156,7 +156,7 @@ EXAMPLES:
 				}
 
 				if len(topicNames) == 0 {
-					return out.Errf(out.ExitUsage, "--topics is required when using --to")
+					return out.Errf(out.ExitUsage, "-t is required when using --to")
 				}
 
 				keepListed := func(lo kadm.ListedOffset) bool {
@@ -305,8 +305,10 @@ EXAMPLES:
 
 	cmd.Flags().StringVar(&to, "to", "", "target offset (start, end, N, @timestamp; mutually exclusive with --to-file)")
 	cmd.Flags().StringVar(&toFile, "to-file", "", "JSON file with per-partition offsets (mutually exclusive with --to)")
-	cmd.Flags().StringArrayVar(&topics, "topics", nil, "topics to seek; repeatable or comma-separated, entries may be topic:p1,p2 (required with --to; optional filter with --to-file)")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview offset changes without applying")
+	cmd.Flags().StringArrayVarP(&topics, "topic", "t", nil, "topics to seek; repeatable or comma-separated, entries may be topic:p1,p2 (required with --to; optional filter with --to-file)")
+	cmd.Flags().StringArrayVar(&topics, "topics", nil, "old name of --topic")
+	cmd.Flags().MarkHidden("topics")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "preview offset changes without applying")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "apply changes without interactive confirmation")
 
 	return cmd

--- a/commands/admin/sharegroup/seek.go
+++ b/commands/admin/sharegroup/seek.go
@@ -34,7 +34,9 @@ func seekCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "seek GROUP",
 		Short: "Reset share group start offsets.",
-		Long: `Reset share group start offsets (KIP-932, Kafka 4.0+).
+		Long: `Reset share group start offsets.
+
+Requires Kafka 4.0+ (KIP-932).
 
 Seek adjusts the start offsets for a share group. The group must be
 empty (no active consumers).

--- a/commands/admin/sharegroup/sharegroup.go
+++ b/commands/admin/sharegroup/sharegroup.go
@@ -114,6 +114,9 @@ Use --section to show only a specific section of the output:
 Defaults: text shows all sections, awk shows offsets.
 `,
 		RunE: func(_ *cobra.Command, groups []string) error {
+			// A group the broker could not describe is printed with its error
+			// and is a failure, as a missing topic is for topic describe.
+			anyErr := false
 			if section != "" {
 				switch client.Strnorm(section) {
 				case "summary":
@@ -341,6 +344,9 @@ Defaults: text shows all sections, awk shows offsets.
 					resp := shard.Resp.(*kmsg.ShareGroupDescribeResponse)
 					for _, group := range resp.Groups {
 						groupErr := kerr.ErrorForCode(group.ErrorCode)
+						if groupErr != nil {
+							anyErr = true
+						}
 						if showSummary {
 							ls := lagByGroup[group.GroupID]
 							printShareGroupSummary(shard.Meta.NodeID, group, ls.totalLag, ls.partCount, ls.nonZeroLag)
@@ -380,6 +386,9 @@ Defaults: text shows all sections, awk shows offsets.
 						fmt.Println()
 					}
 				}
+			}
+			if anyErr {
+				return out.ErrSilent
 			}
 			return nil
 		},

--- a/commands/admin/sharegroup/sharegroup.go
+++ b/commands/admin/sharegroup/sharegroup.go
@@ -42,7 +42,9 @@ func listCommand(cl *client.Client) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List all share groups (Kafka 4.0+).",
-		Long: `List all share groups (KIP-932, Kafka 4.0+).
+		Long: `List all share groups (Kafka 4.0+).
+
+List all share groups (KIP-932, Kafka 4.0+).
 
 This is equivalent to "group list --type-filter share". It lists share groups
 by issuing a ListGroups request with a type filter of "share".
@@ -96,7 +98,9 @@ func describeCommand(cl *client.Client) *cobra.Command {
 		Use:     "describe GROUPS...",
 		Aliases: []string{"d"},
 		Short:   "Describe share groups with offsets and lag (Kafka 4.0+).",
-		Long: `Describe share groups (KIP-932, Kafka 4.0+).
+		Long: `Describe share groups with offsets and lag (Kafka 4.0+).
+
+Describe share groups (KIP-932, Kafka 4.0+).
 
 If no groups are provided, all share groups are listed and then described.
 The output includes group metadata, members, and per-partition start offsets
@@ -472,7 +476,9 @@ func deleteCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete GROUPS...",
 		Short: "Delete share groups (Kafka 4.0+).",
-		Long: `Delete share groups (KIP-932, Kafka 4.0+).
+		Long: `Delete share groups (Kafka 4.0+).
+
+Delete share groups (KIP-932, Kafka 4.0+).
 
 The groups must be empty (no active consumers) to be deleted.
 

--- a/commands/admin/sharegroup/sharegroup.go
+++ b/commands/admin/sharegroup/sharegroup.go
@@ -394,7 +394,7 @@ Defaults: text shows all sections, awk shows offsets.
 		},
 	}
 	cmd.Flags().StringVar(&section, "section", "", "output section (summary, members, offsets; default: all for text, offsets for awk)")
-	cmd.Flags().BoolVar(&regex, "regex", false, "treat group arguments as regular expressions")
+	cmd.Flags().BoolVarP(&regex, "regex", "r", false, "treat group arguments as regular expressions")
 	return cmd
 }
 
@@ -545,8 +545,8 @@ without actually deleting them.
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print groups that would be deleted without actually deleting them")
-	cmd.Flags().BoolVar(&useRegex, "regex", false, "treat group arguments as regex patterns; match against all existing share groups")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "print groups that would be deleted without actually deleting them")
+	cmd.Flags().BoolVarP(&useRegex, "regex", "r", false, "treat group arguments as regex patterns; match against all existing share groups")
 	return cmd
 }
 

--- a/commands/admin/topic/add_partitions_test.go
+++ b/commands/admin/topic/add_partitions_test.go
@@ -1,0 +1,92 @@
+package topic
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+
+	"github.com/twmb/kcl/client"
+)
+
+func partitionCount(t *testing.T, addr, topic string) int {
+	t.Helper()
+	cl, err := kgo.NewClient(kgo.SeedBrokers(addr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	req := kmsg.NewPtrMetadataRequest()
+	rt := kmsg.NewMetadataRequestTopic()
+	rt.Topic = kmsg.StringPtr(topic)
+	req.Topics = append(req.Topics, rt)
+	resp, err := req.RequestWith(context.Background(), cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(resp.Topics[0].Partitions)
+}
+
+func TestAddPartitions(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		args      []string
+		wantParts int
+		wantErr   string
+	}{
+		{name: "-n", args: []string{"foo", "-n", "2"}, wantParts: 4},
+		{name: "-a per partition", args: []string{"foo", "-a", "0", "-a", "0"}, wantParts: 4},
+		{name: "-a in one value", args: []string{"foo", "-a", "0:0"}, wantParts: 4},
+		{name: "old form", args: []string{"-t", "foo", "0", ":", "0"}, wantParts: 4},
+		{name: "--total above", args: []string{"foo", "--total", "5"}, wantParts: 5},
+		{name: "--total at is nothing to do", args: []string{"foo", "--total", "2"}, wantParts: 2},
+		{name: "--total below fails", args: []string{"foo", "--total", "1"}, wantErr: "has 2 partitions, more than --total 1"},
+		{name: "--total with matching -a", args: []string{"foo", "--total", "4", "-a", "0", "-a", "0"}, wantParts: 4},
+		{name: "--total with wrong -a count", args: []string{"foo", "--total", "4", "-a", "0"}, wantErr: "needs 2 new partitions but -a lists 1"},
+		{name: "-n and --total", args: []string{"foo", "-n", "1", "--total", "3"}, wantErr: "exclusive"},
+		{name: "-n and -a", args: []string{"foo", "-n", "1", "-a", "0"}, wantErr: "exclusive"},
+		{name: "nothing", args: []string{"foo"}, wantErr: "nothing to add"},
+		{name: "two topics", args: []string{"foo", "bar", "-n", "1"}, wantErr: "takes one topic"},
+		{name: "wrong replica count", args: []string{"foo", "-a", "0,1"}, wantErr: "each -a must list 1 brokers"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(2, "foo"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			addr := c.ListenAddrs()[0]
+
+			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			cl := client.New(root)
+			root.AddCommand(Command(cl))
+			root.SetArgs(append([]string{"--no-config-file", "-B", addr, "-X", "dial_timeout=2s", "-X", "retry_timeout=10s", "topic", "add-partitions"}, test.args...))
+			r, w, _ := os.Pipe()
+			old := os.Stdout
+			os.Stdout = w
+			execErr := root.Execute()
+			w.Close()
+			os.Stdout = old
+			io.ReadAll(r)
+
+			if test.wantErr != "" {
+				if execErr == nil || !strings.Contains(execErr.Error(), test.wantErr) {
+					t.Fatalf("err = %v, want containing %q", execErr, test.wantErr)
+				}
+				return
+			}
+			if execErr != nil {
+				t.Fatal(execErr)
+			}
+			if got := partitionCount(t, addr, "foo"); got != test.wantParts {
+				t.Errorf("partitions = %d, want %d", got, test.wantParts)
+			}
+		})
+	}
+}

--- a/commands/admin/topic/describe.go
+++ b/commands/admin/topic/describe.go
@@ -547,9 +547,12 @@ func fetchTopicConfigs(ctx context.Context, cl kmsg.Requestor, topics []string) 
 	result := make(map[string][]kmsg.DescribeConfigsResponseResourceConfig)
 	for _, r := range resp.Resources {
 		if err := kerr.ErrorForCode(r.ErrorCode); err != nil {
-			// Route per-resource errors to stderr so they don't
-			// contaminate JSON/awk output on stdout.
-			fmt.Fprintf(os.Stderr, "config error for %s: %v\n", r.ResourceName, err)
+			// A missing topic was already reported from the metadata
+			// response. Route other per-resource errors to stderr so they
+			// don't contaminate JSON/awk output on stdout.
+			if err != kerr.UnknownTopicOrPartition {
+				fmt.Fprintf(os.Stderr, "config error for %s: %v\n", r.ResourceName, err)
+			}
 			continue
 		}
 		// Sort configs: non-default first, then alphabetical.

--- a/commands/admin/topic/describe.go
+++ b/commands/admin/topic/describe.go
@@ -33,8 +33,10 @@ func topicDescribeCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe TOPICS...",
 		Aliases: []string{"d"},
-		Short:   "Describe topics with partition detail",
-		Long: `Describe topics showing summary, partitions, and optionally configs.
+		Short:   "Describe topics with partition detail.",
+		Long: `Describe topics with partition detail.
+
+Describe topics showing summary, partitions, and optionally configs.
 
 By default in text mode, shows all sections. Use --section to select one.
 AWK mode defaults to partitions. JSON always includes all sections.

--- a/commands/admin/topic/topic.go
+++ b/commands/admin/topic/topic.go
@@ -360,43 +360,60 @@ without actually deleting them.
 func topicAddPartitionsCommand(cl *client.Client) *cobra.Command {
 	var topics []string
 	var force bool
+	var num, total int
+	var assigns []string
 
 	cmd := &cobra.Command{
-		Use:   "add-partitions -t TOPIC ASSIGNMENTS",
+		Use:   "add-partitions TOPIC",
 		Short: "Add partitions to a topic.",
 		Long: `Add partitions to a topic.
 
 Requires Kafka 1.0.0+.
 
-As a client, adding partitions to topics is done by requesting a total amount
-of partitions for a topic combined with an assignment of which brokers should
-own the replicas of each new partition.
-
-This CLI handles the total count of final partitions; you as a user just need
-to specify the where new partitions and their replicas should go.
-
-When adding partitions to multiple topics, all topics use the same assignment.
-
-The assignment format is
-
-  replica,replica : replica,replica
-  \             /   \             /
-   one partition     one partition
+-n adds that many partitions and lets the broker place their replicas.
+--total brings the topic to that many partitions: a topic already past it is
+an error, one already there is nothing to do, otherwise the difference is
+added. -a places the new partitions yourself, one -a per partition listing
+the brokers its replicas go on, comma separated, leader first; -a '1,2:3,1'
+in one value is the same as -a 1,2 -a 3,1. Each new partition must have as
+many replicas as the existing ones.
 `,
 
-		Example: `To add three partitions with two replicas each,
-add-partitions -t foo 1,2 : 3,1 : 2,3
+		Example: `add-partitions foo -n 3                  # three more, broker places replicas
+add-partitions foo --total 12            # up to twelve; nothing to do if already there
+add-partitions foo -a 1,2 -a 3,1 -a 2,3  # three more, on brokers 1+2, 3+1, 2+3`,
 
-To add three partitions with one replica each,
-add-partitions -t foo 1:2:3
-
-To add a single partition with three replicas to two topics,
-add-partitions -t bar -t baz 1, 2, 3`,
-
-		Args: cobra.MinimumNArgs(1),
+		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if len(topics) == 0 {
-				return out.Errf(out.ExitUsage, "missing topics to add partitions to")
+			// With -t this is the old form: the positionals are the
+			// assignments, "1,2 : 3,1". Without it the one positional is
+			// the topic and -n or -a says what to add.
+			var assignments []kmsg.CreatePartitionsRequestTopicAssignment
+			var err error
+			if len(topics) > 0 {
+				if assignments, err = parseAssignments(strings.Join(args, "")); err != nil {
+					return fmt.Errorf("parse assignments failure: %v", err)
+				}
+				if len(assignments) == 0 {
+					return out.Errf(out.ExitUsage, "no new partitions requested")
+				}
+			} else {
+				if len(args) != 1 {
+					return out.Errf(out.ExitUsage, "add-partitions takes one topic, then -n COUNT or -a BROKERS once per new partition")
+				}
+				topics = args
+				switch {
+				case num > 0 && total > 0:
+					return out.Errf(out.ExitUsage, "-n and --total are exclusive")
+				case num > 0 && len(assigns) > 0:
+					return out.Errf(out.ExitUsage, "-n and -a are exclusive: -n lets the broker place replicas, -a places them")
+				case len(assigns) > 0:
+					if assignments, err = parseAssignments(strings.Join(assigns, ":")); err != nil {
+						return out.Errf(out.ExitUsage, "invalid -a: %v", err)
+					}
+				case num == 0 && total == 0:
+					return out.Errf(out.ExitUsage, "nothing to add: pass -n COUNT, --total COUNT, or -a BROKERS once per new partition")
+				}
 			}
 
 			for _, topic := range topics {
@@ -406,14 +423,6 @@ add-partitions -t bar -t baz 1, 2, 3`,
 				if strings.HasPrefix(topic, "__") && force {
 					fmt.Fprintf(os.Stderr, "WARNING: modifying internal topic %q; this can cause system instability\n", topic)
 				}
-			}
-
-			assignments, err := parseAssignments(strings.Join(args, ""))
-			if err != nil {
-				return fmt.Errorf("parse assignments failure: %v", err)
-			}
-			if len(assignments) == 0 {
-				return out.Errf(out.ExitUsage, "no new partitions requested")
 			}
 
 			// Get the metadata so we can determine the final partition count.
@@ -436,21 +445,41 @@ add-partitions -t bar -t baz 1, 2, 3`,
 					return fmt.Errorf("metadata returned nil topic, unknown topic ID!")
 				}
 				currentPartitionCount := len(topic.Partitions)
-				if currentPartitionCount > 0 {
+				adding := num
+				if len(assignments) > 0 {
+					adding = len(assignments)
+				}
+				if total > 0 {
+					switch {
+					case currentPartitionCount > total:
+						return out.Errf(out.ExitError, "topic %s has %d partitions, more than --total %d", *topic.Topic, currentPartitionCount, total)
+					case currentPartitionCount == total:
+						fmt.Fprintf(os.Stderr, "topic %s already has %d partitions\n", *topic.Topic, total)
+						continue
+					}
+					if want := total - currentPartitionCount; len(assignments) > 0 && len(assignments) != want {
+						return out.Errf(out.ExitUsage, "--total %d needs %d new partitions but -a lists %d", total, want, len(assignments))
+					} else {
+						adding = want
+					}
+				}
+				if currentPartitionCount > 0 && len(assignments) > 0 {
 					currentReplicaCount := len(topic.Partitions[0].Replicas)
 					if currentReplicaCount != len(assignments[0].Replicas) {
-						fmt.Fprintf(os.Stderr, "ERR: requested topic %s has partitions with %d replicas; you cannot create a new partition with %d (must match)",
-							*topic.Topic, currentReplicaCount, len(assignments[0].Replicas))
+						return out.Errf(out.ExitUsage, "topic %s has %d replicas per partition; each -a must list %d brokers", *topic.Topic, currentReplicaCount, currentReplicaCount)
 					}
 				}
 
 				createReq.Topics = append(createReq.Topics, kmsg.CreatePartitionsRequestTopic{
 					Topic:      *topic.Topic,
-					Count:      int32(currentPartitionCount + len(assignments)),
+					Count:      int32(currentPartitionCount + adding),
 					Assignment: assignments,
 				})
 			}
 
+			if len(createReq.Topics) == 0 {
+				return nil
+			}
 			createResp, err := cl.Client().Request(context.Background(), &createReq)
 			if err != nil {
 				return fmt.Errorf("unable to create topic partitions: %v", err)
@@ -475,7 +504,11 @@ add-partitions -t bar -t baz 1, 2, 3`,
 		},
 	}
 
-	cmd.Flags().StringArrayVarP(&topics, "topic", "t", nil, "topic to add partitions to; repeatable")
+	cmd.Flags().IntVarP(&num, "num", "n", 0, "number of partitions to add; the broker places their replicas")
+	cmd.Flags().IntVar(&total, "total", 0, "partition count to bring the topic to; past it fails, at it does nothing")
+	cmd.Flags().StringArrayVarP(&assigns, "assignment", "a", nil, "brokers for one new partition, comma separated, leader first; repeat once per partition")
+	cmd.Flags().StringArrayVarP(&topics, "topic", "t", nil, "old form: topic to add partitions to, with the assignments as arguments")
+	cmd.Flags().MarkHidden("topic")
 	cmd.Flags().BoolVar(&force, "force", false, "allow modifying internal topics (those starting with \"__\")")
 
 	return cmd

--- a/commands/admin/topic/topic.go
+++ b/commands/admin/topic/topic.go
@@ -78,7 +78,7 @@ func topicCreateCommand(cl *client.Client) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:     "create TOPICS",
+		Use:     "create TOPICS...",
 		Aliases: []string{"c"},
 		Short:   "Create topics.",
 		Long: `Create topics.

--- a/commands/admin/topic/topic.go
+++ b/commands/admin/topic/topic.go
@@ -80,8 +80,10 @@ func topicCreateCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create TOPICS",
 		Aliases: []string{"c"},
-		Short:   "Create topics",
-		Long: `Create topics (Kafka 0.10.1+).
+		Short:   "Create topics.",
+		Long: `Create topics.
+
+Requires Kafka 0.10.1+.
 
 All topics created with this command will have the same number of partitions,
 replication factor, and key/value configs.
@@ -188,7 +190,7 @@ func topicListCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List all topics",
+		Short:   "List all topics.",
 		Long: `List all topics.
 
 EXAMPLES:
@@ -361,8 +363,10 @@ func topicAddPartitionsCommand(cl *client.Client) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "add-partitions -t TOPIC ASSIGNMENTS",
-		Short: "Add partitions to a topic",
-		Long: `Add partitions to a topic (Kafka 1.0.0+).
+		Short: "Add partitions to a topic.",
+		Long: `Add partitions to a topic.
+
+Requires Kafka 1.0.0+.
 
 As a client, adding partitions to topics is done by requesting a total amount
 of partitions for a topic combined with an assignment of which brokers should

--- a/commands/admin/topic/topic.go
+++ b/commands/admin/topic/topic.go
@@ -231,7 +231,7 @@ EXAMPLES:
 	}
 	cmd.Flags().BoolVarP(&detailed, "detailed", "d", false, "include detailed information about all topic partitions")
 	cmd.Flags().BoolVarP(&showInternal, "internal", "i", false, "include internal topics")
-	cmd.Flags().StringVar(&regexFilter, "regex", "", "filter topics by regex pattern")
+	cmd.Flags().StringVarP(&regexFilter, "regex", "r", "", "filter topics by regex pattern")
 	return cmd
 }
 
@@ -352,8 +352,8 @@ without actually deleting them.
 		},
 	}
 	cmd.Flags().BoolVar(&ids, "ids", false, "whether the input topics should be parsed as topic IDs")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print topics that would be deleted without actually deleting them")
-	cmd.Flags().BoolVar(&useRegex, "regex", false, "treat topic arguments as regex patterns; match against all existing topics")
+	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "print topics that would be deleted without actually deleting them")
+	cmd.Flags().BoolVarP(&useRegex, "regex", "r", false, "treat topic arguments as regex patterns; match against all existing topics")
 	return cmd
 }
 

--- a/commands/admin/topic/trim_prefix.go
+++ b/commands/admin/topic/trim_prefix.go
@@ -209,8 +209,8 @@ SEE ALSO:
 		},
 	}
 
-	cmd.Flags().StringVar(&offsetFlag, "offset", "", "offset or timestamp to trim before (N, end, @timestamp)")
-	cmd.Flags().Int32SliceVar(&partitions, "partitions", nil, "limit to specific partitions (default: all)")
+	cmd.Flags().StringVarP(&offsetFlag, "offset", "o", "", "offset or timestamp to trim before (N, end, @timestamp)")
+	cmd.Flags().Int32SliceVarP(&partitions, "partitions", "p", nil, "limit to specific partitions (default: all)")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompt")
 	cmd.Flags().StringVar(&fromFile, "from-file", "", "JSON file of [{topic, partition, offset}, ...] to trim")
 

--- a/commands/admin/topic/trim_prefix.go
+++ b/commands/admin/topic/trim_prefix.go
@@ -32,7 +32,9 @@ func topicTrimPrefixCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trim-prefix TOPIC",
 		Short: "Delete records before a given offset or timestamp.",
-		Long: `Delete records before a given offset or timestamp (Kafka 0.11.0+).
+		Long: `Delete records before a given offset or timestamp.
+
+Requires Kafka 0.11.0+.
 
 This is a user-friendly wrapper around DeleteRecords. It resolves symbolic
 offsets (timestamps, 'end', relative) via ListOffsets before issuing the

--- a/commands/admin/txn/txn.go
+++ b/commands/admin/txn/txn.go
@@ -35,7 +35,9 @@ func describeProducers(cl *client.Client) *cobra.Command {
 		Use:     "describe-producers",
 		Aliases: []string{"dp"},
 		Short:   "Describe active producers.",
-		Long: `Describe idempotent and transactional producers (Kafka 2.8.0+)
+		Long: `Describe active producers.
+
+Describe idempotent and transactional producers (Kafka 2.8.0+)
 
 From KIP-664, this command is sent to partition leaders to describe the state
 of active idempotent and transactional producers.
@@ -139,7 +141,9 @@ func listCommand(cl *client.Client) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List active transactions (Kafka 3.0+).",
-		Long: `List active transactions across all brokers (Kafka 3.0+).
+		Long: `List active transactions (Kafka 3.0+).
+
+List active transactions across all brokers (Kafka 3.0+).
 
 This command lists all ongoing transactions. You can optionally filter by
 transaction state or producer ID.
@@ -181,7 +185,9 @@ func describeCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "describe TRANSACTIONAL_IDS...",
 		Short: "Describe transactions (Kafka 3.0+).",
-		Long: `Describe active transactions by transactional ID (Kafka 3.0+).
+		Long: `Describe transactions (Kafka 3.0+).
+
+Describe active transactions by transactional ID (Kafka 3.0+).
 
 This command describes the state of one or more transactions, including
 the producer ID, epoch, timeout, and the topics/partitions involved.

--- a/commands/admin/userscram/user_scram.go
+++ b/commands/admin/userscram/user_scram.go
@@ -64,8 +64,11 @@ func describeUserSCRAM(cl *client.Client) *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"d"},
 		Short:   "Describe user scram credentials.",
-		Long:    `Describe user scram credentials (Kafka 2.7.0+)`,
-		Args:    cobra.ExactArgs(0),
+		Long: `List user SCRAM credentials.
+
+Requires Kafka 2.7.0+.
+`,
+		Args: cobra.ExactArgs(0),
 
 		RunE: func(_ *cobra.Command, _ []string) error {
 			var req kmsg.DescribeUserSCRAMCredentialsRequest
@@ -121,7 +124,9 @@ func alterUserSCRAM(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "alter",
 		Short: "Alter user scram credentials.",
-		Long: `Alter user scram credentials (Kafka 2.7.0+)
+		Long: `Alter user scram credentials.
+
+Requires Kafka 2.7.0+.
 
 Both deleting and setting have the same input format, with setting requiring
 more keys.

--- a/commands/admin/userscram/user_scram.go
+++ b/commands/admin/userscram/user_scram.go
@@ -293,7 +293,7 @@ Both --set and --del can be specified many times.
 	}
 
 	cmd.Flags().StringArrayVar(&dels, "del", nil, "user and mechanism pairing to delete, repeatable")
-	cmd.Flags().StringArrayVar(&sets, "set", nil, "user and mechanism pairing to insert or update, repeatable")
+	cmd.Flags().StringArrayVarP(&sets, "set", "s", nil, "user and mechanism pairing to insert or update, repeatable")
 
 	return cmd
 }

--- a/commands/cluster/voter.go
+++ b/commands/cluster/voter.go
@@ -27,7 +27,9 @@ func addControllerCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add-controller",
 		Short: "Add a voter to the KRaft quorum (KIP-853).",
-		Long: `Add a voter (controller) to the KRaft quorum (KIP-853, Kafka 4.0+).
+		Long: `Add a voter to the KRaft quorum (KIP-853).
+
+Add a voter (controller) to the KRaft quorum (KIP-853, Kafka 4.0+).
 
 Only one controller can be added at a time. The new controller must be
 running and reachable via the specified listeners.
@@ -107,7 +109,9 @@ func removeControllerCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove-controller",
 		Short: "Remove a voter from the KRaft quorum (KIP-853).",
-		Long: `Remove a voter (controller) from the KRaft quorum (KIP-853, Kafka 4.0+).
+		Long: `Remove a voter from the KRaft quorum (KIP-853).
+
+Remove a voter (controller) from the KRaft quorum (KIP-853, Kafka 4.0+).
 
 Only one controller can be removed at a time.
 

--- a/commands/consume/command.go
+++ b/commands/consume/command.go
@@ -12,7 +12,7 @@ func (c *consumption) command() *cobra.Command {
 	var topicFlags []string
 	cmd := &cobra.Command{
 		Use:   "consume [TOPICS...]",
-		Short: "Consume topic records",
+		Short: "Consume topic records.",
 		Long:  help,
 		RunE: func(_ *cobra.Command, args []string) error {
 			topics := append(args, topicFlags...)
@@ -52,7 +52,9 @@ func (c *consumption) command() *cobra.Command {
 	return cmd
 }
 
-const help = `Consume topic records and print them.
+const help = `Consume topic records.
+
+Consume topic records and print them.
 
 This function consumes Kafka topics and prints the records with a configurable
 format. The output format takes similar arguments as kafkacat, with the default
@@ -202,7 +204,7 @@ times. If the parser needs more data than available, or if more input remains
 after '$', an error message will be appended.
 
 
-EXAMPLES
+EXAMPLES:
 
 Default (value only, newline-delimited):
   -f '%v\n'

--- a/commands/consume/consume.go
+++ b/commands/consume/consume.go
@@ -15,7 +15,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sr"
 
 	"github.com/twmb/kcl/client"
@@ -69,6 +71,27 @@ type consumption struct {
 // Command returns a consume command.
 func Command(cl *client.Client) *cobra.Command {
 	return (&consumption{cl: cl}).command()
+}
+
+// checkTopicsExist errors if any of topics is unknown to the cluster. The
+// metadata request does not allow auto creation, so asking does not create.
+func checkTopicsExist(ctx context.Context, cl *kgo.Client, topics []string) error {
+	req := kmsg.NewPtrMetadataRequest()
+	for _, topic := range topics {
+		rt := kmsg.NewMetadataRequestTopic()
+		rt.Topic = kmsg.StringPtr(topic)
+		req.Topics = append(req.Topics, rt)
+	}
+	resp, err := req.RequestWith(ctx, cl)
+	if err != nil {
+		return fmt.Errorf("unable to check that topics exist: %v", err)
+	}
+	for _, t := range resp.Topics {
+		if err := kerr.ErrorForCode(t.ErrorCode); err != nil && t.Topic != nil {
+			return out.Errf(out.ExitError, "unable to consume topic %q: %v", *t.Topic, err)
+		}
+	}
+	return nil
 }
 
 func (c *consumption) run(topics []string) error {
@@ -218,6 +241,15 @@ func (c *consumption) run(topics []string) error {
 			cancel()
 		}
 	}()
+
+	// A literal topic that does not exist is a typo far more often than a
+	// topic about to be created, so we fail rather than wait; --regex is
+	// the way to wait for topics to appear.
+	if !c.regex {
+		if err := checkTopicsExist(ctx, cl, topics); err != nil {
+			return err
+		}
+	}
 
 	// Resolve timestamp-based start offsets via ListOffsetsAfterMilli.
 	if c.startTimestampMillis >= 0 {

--- a/commands/consume/topics_exist_test.go
+++ b/commands/consume/topics_exist_test.go
@@ -1,0 +1,53 @@
+package consume
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/twmb/kcl/out"
+)
+
+func TestCheckTopicsExist(t *testing.T) {
+	c, err := kfake.NewCluster(kfake.SeedTopics(1, "exists"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	cl, err := kgo.NewClient(kgo.SeedBrokers(c.ListenAddrs()...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, test := range []struct {
+		name    string
+		topics  []string
+		wantErr string
+	}{
+		{name: "present", topics: []string{"exists"}},
+		{name: "missing", topics: []string{"nope"}, wantErr: `unable to consume topic "nope"`},
+		{name: "one of two missing", topics: []string{"exists", "nope"}, wantErr: `"nope"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkTopicsExist(ctx, cl, test.topics)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			var ce *out.ExitCodeError
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) || !errors.As(err, &ce) || ce.Code != out.ExitError {
+				t.Fatalf("err = %v, want exit %d containing %q", err, out.ExitError, test.wantErr)
+			}
+		})
+	}
+}

--- a/commands/fake/fake.go
+++ b/commands/fake/fake.go
@@ -64,7 +64,7 @@ topics, records, consumer group offsets, and transactional producer
 state across restarts. Pass --sync to fsync every write (slower but
 safest).
 
-EXAMPLES
+EXAMPLES:
 
 Default three-broker cluster:
 

--- a/commands/metadata/metadata.go
+++ b/commands/metadata/metadata.go
@@ -25,8 +25,10 @@ func Command(cl *client.Client) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "metadata [TOPICS]",
-		Short: "Issue a metadata command and dump the results",
-		Long: `Request metadata (0.8.0+).
+		Short: "Issue a metadata command and dump the results.",
+		Long: `Show cluster metadata.
+
+Request metadata (0.8.0+).
 
 Kafka's metadata contains a good deal of information about brokers, topics,
 and the cluster as a whole. This is the command to use to get general info

--- a/commands/misc/misc.go
+++ b/commands/misc/misc.go
@@ -34,7 +34,7 @@ func apiVersionsRequest() *kmsg.ApiVersionsRequest {
 func Command(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "misc",
-		Short: "Miscellaneous utilities (version probing, error code/text, offset listing)",
+		Short: "Miscellaneous utilities (version probing, error code/text, offset listing).",
 	}
 
 	cmd.AddCommand(errcodeCommand())
@@ -52,7 +52,7 @@ func Command(cl *client.Client) *cobra.Command {
 func errcodeCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "errcode CODE",
-		Short: "Print the name and description for an error code",
+		Short: "Print the name and description for an error code.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			code, err := strconv.Atoi(args[0])
@@ -74,7 +74,7 @@ func errtextCommand() *cobra.Command {
 	var list, verbose bool
 	cmd := &cobra.Command{
 		Use:   "errtext [ERROR_NAME]",
-		Short: "Print the name, code and description for an error name or all errors",
+		Short: "Print the name, code and description for an error name or all errors.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			var text string
@@ -123,8 +123,10 @@ func genAutocompleteCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "gen-autocomplete",
-		Short: "Generates bash completion scripts",
-		Long: `To load completion run
+		Short: "Generates bash completion scripts.",
+		Long: `Generates bash completion scripts.
+
+To load completion run
 
 . <(kcl misc gen-autocomplete -kbash)
 
@@ -222,7 +224,7 @@ func apiVersionsCommand(cl *client.Client) *cobra.Command {
 func probeVersionCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "probe-version",
-		Short: "Probe and print the version of Kafka running (incompatible with --as-version)",
+		Short: "Probe and print the version of Kafka running (incompatible with --as-version).",
 		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {
 			probeVersion(cl)
@@ -353,7 +355,9 @@ func listOffsetsCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-offsets",
 		Short: "List start, stable, and end offsets for partitions.",
-		Long: `List start, stable, and end offsets for topics or partitions (Kafka 0.10.0+).
+		Long: `List start, stable, and end offsets for partitions.
+
+List start, stable, and end offsets for topics or partitions (Kafka 0.10.0+).
 
 The input format is topic:#,#,# or just topic. If a topic is given without
 partitions, a metadata request is issued to figure out all partitions for the

--- a/commands/misc/misc.go
+++ b/commands/misc/misc.go
@@ -49,22 +49,36 @@ func Command(cl *client.Client) *cobra.Command {
 	return cmd
 }
 
+// printKerr prints one Kafka error in the requested format; text is the
+// text form, which differs between errcode and errtext.
+func printKerr(format, command string, code int16, name, description, text string) {
+	switch format {
+	case out.FormatJSON:
+		out.MarshalJSON(command, 1, map[string]any{"code": code, "name": name, "description": description})
+	case out.FormatAWK:
+		fmt.Printf("%s\t%d\t%s\n", name, code, description)
+	default:
+		fmt.Print(text)
+	}
+}
+
 func errcodeCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "errcode CODE",
 		Short: "Print the name and description for an error code.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			code, err := strconv.Atoi(args[0])
 			if err != nil {
 				return fmt.Errorf("unable to parse error code: %v", err)
 			}
+			format, _ := cmd.Flags().GetString("format")
 			if code == 0 {
-				fmt.Println("NONE")
+				printKerr(format, "misc.errcode", 0, "NONE", "", "NONE\n")
 				return nil
 			}
 			kerr := kerr.ErrorForCode(int16(code)).(*kerr.Error)
-			fmt.Printf("%s\n%s\n", kerr.Message, kerr.Description)
+			printKerr(format, "misc.errcode", kerr.Code, kerr.Message, kerr.Description, fmt.Sprintf("%s\n%s\n", kerr.Message, kerr.Description))
 			return nil
 		},
 	}
@@ -76,7 +90,8 @@ func errtextCommand() *cobra.Command {
 		Use:   "errtext [ERROR_NAME]",
 		Short: "Print the name, code and description for an error name or all errors.",
 		Args:  cobra.MaximumNArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, _ := cmd.Flags().GetString("format")
 			var text string
 			if list {
 				if len(args) != 0 {
@@ -90,12 +105,21 @@ func errtextCommand() *cobra.Command {
 				}
 			}
 
+			var table *out.FormattedTable
+			if list && format != out.FormatText {
+				table = out.NewFormattedTable(format, "misc.errtext", 1, "errors", "NAME", "CODE", "DESCRIPTION")
+				defer table.Flush()
+			}
 			var err error
 			for code := int16(1); err != kerr.UnknownServerError; code++ {
 				err = kerr.ErrorForCode(code)
 				kerr := err.(*kerr.Error)
 				if list {
-					fmt.Printf("%s (%d)\n%s\n\n", kerr.Message, kerr.Code, kerr.Description)
+					if table != nil {
+						table.Row(kerr.Message, kerr.Code, kerr.Description)
+					} else {
+						fmt.Printf("%s (%d)\n%s\n\n", kerr.Message, kerr.Code, kerr.Description)
+					}
 					continue
 				}
 
@@ -103,7 +127,7 @@ func errtextCommand() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "trying %s...\n", kerr.Message)
 				}
 				if client.Strnorm(kerr.Message) == text {
-					fmt.Printf("%s (%d)\n%s\n", kerr.Message, kerr.Code, kerr.Description)
+					printKerr(format, "misc.errtext", kerr.Code, kerr.Message, kerr.Description, fmt.Sprintf("%s (%d)\n%s\n", kerr.Message, kerr.Code, kerr.Description))
 					return nil
 				}
 			}
@@ -287,6 +311,9 @@ The wire version used is:
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if key < 0 {
+				return out.Errf(out.ExitUsage, "--key is required")
+			}
 			req := kmsg.RequestForKey(key)
 			if req == nil {
 				return out.Errf(out.ExitUsage, "request key %d unknown", key)

--- a/commands/misc/misc.go
+++ b/commands/misc/misc.go
@@ -380,7 +380,7 @@ func listOffsetsCommand(cl *client.Client) *cobra.Command {
 	var readCommitted bool
 
 	cmd := &cobra.Command{
-		Use:   "list-offsets",
+		Use:   "list-offsets TOPICS...",
 		Short: "List start, stable, and end offsets for partitions.",
 		Long: `List start, stable, and end offsets for partitions.
 

--- a/commands/misc/misc_format_test.go
+++ b/commands/misc/misc_format_test.go
@@ -1,0 +1,73 @@
+package misc
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/twmb/kcl/client"
+	"github.com/twmb/kcl/out"
+)
+
+func runMisc(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+	cl := client.New(root)
+	root.AddCommand(Command(cl))
+	root.SetArgs(append([]string{"--no-config-file"}, args...))
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	execErr := root.Execute()
+	w.Close()
+	os.Stdout = old
+	b, _ := io.ReadAll(r)
+	return string(b), execErr
+}
+
+func TestRawReqNeedsKey(t *testing.T) {
+	_, err := runMisc(t, "misc", "raw-req")
+	var ce *out.ExitCodeError
+	if err == nil || !strings.Contains(err.Error(), "--key is required") || !errors.As(err, &ce) || ce.Code != out.ExitUsage {
+		t.Fatalf("err = %v, want exit 2 naming --key", err)
+	}
+}
+
+func TestErrcodeAndErrtextFormats(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want string // substring of stdout
+		json bool
+	}{
+		{name: "errcode text", args: []string{"misc", "errcode", "6"}, want: "NOT_LEADER_FOR_PARTITION\nThis server is not the leader"},
+		{name: "errcode json", args: []string{"--format", "json", "misc", "errcode", "6"}, want: `"name": "NOT_LEADER_FOR_PARTITION"`, json: true},
+		{name: "errcode awk", args: []string{"--format", "awk", "misc", "errcode", "6"}, want: "NOT_LEADER_FOR_PARTITION\t6\tThis server"},
+		{name: "errcode none json", args: []string{"--format", "json", "misc", "errcode", "0"}, want: `"name": "NONE"`, json: true},
+		{name: "errtext text", args: []string{"misc", "errtext", "NOT_LEADER_FOR_PARTITION"}, want: "NOT_LEADER_FOR_PARTITION (6)\n"},
+		{name: "errtext json", args: []string{"--format", "json", "misc", "errtext", "NOT_LEADER_FOR_PARTITION"}, want: `"code": 6`, json: true},
+		{name: "errtext list awk", args: []string{"--format", "awk", "misc", "errtext", "--list"}, want: "\nNOT_LEADER_FOR_PARTITION\t6\t"},
+		{name: "errtext list json", args: []string{"--format", "json", "misc", "errtext", "--list"}, want: `"_command": "misc.errtext"`, json: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := runMisc(t, test.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got, test.want) {
+				t.Errorf("stdout lacks %q:\n%s", test.want, got)
+			}
+			if test.json && !json.Valid([]byte(got)) {
+				t.Errorf("not JSON:\n%s", got)
+			}
+		})
+	}
+}

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -2,10 +2,13 @@
 package myconfig
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -110,6 +113,14 @@ func listCommand(cl *client.Client) *cobra.Command {
 				return fmt.Errorf("unable to read config: %v", err)
 			}
 
+			if cl.Format() != out.FormatText {
+				table := out.NewFormattedTable(cl.Format(), "profile.list", 1, "profiles", "NAME", "CURRENT")
+				for _, n := range profileNames(cfgFile) {
+					table.Row(n, n == cfgFile.CurrentProfile)
+				}
+				table.Flush()
+				return nil
+			}
 			if len(cfgFile.Profiles) == 0 {
 				fmt.Fprintln(os.Stderr, "No profiles configured. Config uses flat format.")
 				return nil
@@ -148,10 +159,17 @@ func currentCommand(cl *client.Client) *cobra.Command {
 			} else {
 				name = cfgFile.CurrentProfile
 			}
-			if name == "" {
-				fmt.Fprintln(os.Stderr, "(no profile set)")
-			} else {
+			switch cl.Format() {
+			case out.FormatJSON:
+				out.MarshalJSON("profile.current", 1, map[string]any{"profile": name})
+			case out.FormatAWK:
 				fmt.Println(name)
+			default:
+				if name == "" {
+					fmt.Fprintln(os.Stderr, "(no profile set)")
+				} else {
+					fmt.Println(name)
+				}
 			}
 			return nil
 		},
@@ -299,6 +317,44 @@ func setProfile(path, name string, apply func(*client.Cfg) error) (string, error
 	return fmt.Sprintf("profile %q", name), nil
 }
 
+// cfgMap renders cfg as nested maps keyed by the TOML names, for JSON.
+func cfgMap(cfg client.Cfg) (map[string]any, error) {
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(cfg); err != nil {
+		return nil, fmt.Errorf("unable to encode config: %v", err)
+	}
+	m := make(map[string]any)
+	if _, err := toml.Decode(buf.String(), &m); err != nil {
+		return nil, fmt.Errorf("unable to decode config: %v", err)
+	}
+	return m, nil
+}
+
+// flattenCfg turns nested maps into sorted dotted key and value pairs, lists
+// joined with commas, for the awk format.
+func flattenCfg(prefix string, m map[string]any) [][2]string {
+	var out [][2]string
+	for _, k := range slices.Sorted(maps.Keys(m)) {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch v := m[k].(type) {
+		case map[string]any:
+			out = append(out, flattenCfg(key, v)...)
+		case []any:
+			strs := make([]string, len(v))
+			for i, e := range v {
+				strs[i] = fmt.Sprint(e)
+			}
+			out = append(out, [2]string{key, strings.Join(strs, ",")})
+		default:
+			out = append(out, [2]string{key, fmt.Sprint(v)})
+		}
+	}
+	return out
+}
+
 // setMessage says what set did: "Set a, b", "Unset c", or "Set a; unset c".
 func setMessage(set, unset []string) string {
 	set, unset = uniq(set), uniq(unset)
@@ -397,8 +453,27 @@ func dumpCommand(cl *client.Client) *cobra.Command {
 		Use:   "dump",
 		Short: "Dump the loaded configuration, with ${NAME} references as written.",
 		Args:  cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
-			toml.NewEncoder(os.Stdout).Encode(cl.DiskCfg())
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cfg := cl.DiskCfg()
+			switch cl.Format() {
+			case out.FormatJSON:
+				m, err := cfgMap(cfg)
+				if err != nil {
+					return err
+				}
+				out.MarshalJSON("profile.dump", 1, m)
+			case out.FormatAWK:
+				m, err := cfgMap(cfg)
+				if err != nil {
+					return err
+				}
+				for _, kv := range flattenCfg("", m) {
+					fmt.Printf("%s\t%s\n", kv[0], kv[1])
+				}
+			default:
+				return toml.NewEncoder(os.Stdout).Encode(cfg)
+			}
+			return nil
 		},
 	}
 }

--- a/commands/myconfig/command.go
+++ b/commands/myconfig/command.go
@@ -43,7 +43,7 @@ func Command(cl *client.Client) *cobra.Command {
 func DeprecatedCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "myconfig",
-		Short:      "kcl configuration commands",
+		Short:      "kcl configuration commands.",
 		Deprecated: "use 'kcl profile' instead",
 		Hidden:     true,
 	}
@@ -68,7 +68,7 @@ func DeprecatedCommand(cl *client.Client) *cobra.Command {
 func useCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "use NAME",
-		Short: "Switch the active profile",
+		Short: "Switch the active profile.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
@@ -100,7 +100,7 @@ func listCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List all profiles",
+		Short:   "List all profiles.",
 		Args:    cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cfgPath := cl.CfgFilePath()
@@ -406,7 +406,7 @@ func dumpCommand(cl *client.Client) *cobra.Command {
 func renameCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "rename OLD NEW",
-		Short: "Rename a profile",
+		Short: "Rename a profile.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			oldName, newName := args[0], args[1]
@@ -443,7 +443,7 @@ func renameCommand(cl *client.Client) *cobra.Command {
 func deleteCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete NAME",
-		Short: "Delete a profile",
+		Short: "Delete a profile.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
@@ -528,7 +528,7 @@ func linkCommand(cl *client.Client) *cobra.Command {
 	dir := filepath.Dir(cl.DefaultCfgPath())
 	return &cobra.Command{
 		Use:        "link NAME",
-		Short:      "Link a config file (deprecated: use 'profile use')",
+		Short:      "Link a config file (deprecated: use 'profile use').",
 		Deprecated: "use 'kcl profile use' instead",
 		Hidden:     true,
 		Args:       cobra.ExactArgs(1),
@@ -582,7 +582,7 @@ func linkCommand(cl *client.Client) *cobra.Command {
 func unlinkCommand(cl *client.Client) *cobra.Command {
 	return &cobra.Command{
 		Use:        "unlink",
-		Short:      "Remove config symlink (deprecated: use 'profile use')",
+		Short:      "Remove config symlink (deprecated: use 'profile use').",
 		Deprecated: "use 'kcl profile use' instead",
 		Hidden:     true,
 		Args:       cobra.ExactArgs(0),

--- a/commands/myconfig/profile_test.go
+++ b/commands/myconfig/profile_test.go
@@ -1,6 +1,7 @@
 package myconfig
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -721,5 +722,61 @@ func TestCurrentHonorsProfileFlag(t *testing.T) {
 				t.Errorf("stdout = %q, want %q", outb, test.want)
 			}
 		})
+	}
+}
+
+func TestProfileFormats(t *testing.T) {
+	const profiles = "current_profile = \"prod\"\n[profiles.prod]\nseed_brokers = [\"p:9092\", \"q:9092\"]\ndial_timeout = \"2s\"\n[profiles.prod.sasl]\nmethod = \"plain\"\n[profiles.dev]\nseed_brokers = [\"d:9092\"]\n"
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+		json bool
+	}{
+		{name: "list json", args: []string{"--format", "json", "profile", "list"}, want: `"name": "prod"`, json: true},
+		{name: "list awk", args: []string{"--format", "awk", "profile", "list"}, want: "dev\tfalse\nprod\ttrue\n"},
+		{name: "current json", args: []string{"--format", "json", "profile", "current"}, want: `"profile": "prod"`, json: true},
+		{name: "current awk with -C", args: []string{"--format", "awk", "-C", "dev", "profile", "current"}, want: "dev\n"},
+		{name: "dump text is toml", args: []string{"profile", "dump"}, want: "seed_brokers = [\"p:9092\", \"q:9092\"]"},
+		{name: "dump json", args: []string{"--format", "json", "profile", "dump"}, want: `"method": "plain"`, json: true},
+		{name: "dump awk", args: []string{"--format", "awk", "profile", "dump"}, want: "sasl.method\tplain\nseed_brokers\tp:9092,q:9092\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(profiles), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			cl := client.New(root)
+			root.AddCommand(Command(cl))
+			root.SetArgs(append([]string{"--config-path", path}, test.args...))
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			old := os.Stdout
+			os.Stdout = w
+			execErr := root.Execute()
+			w.Close()
+			os.Stdout = old
+			outb, _ := io.ReadAll(r)
+			if execErr != nil {
+				t.Fatal(execErr)
+			}
+			if !strings.Contains(string(outb), test.want) {
+				t.Errorf("stdout lacks %q:\n%s", test.want, outb)
+			}
+			if test.json && !json.Valid(outb) {
+				t.Errorf("not JSON:\n%s", outb)
+			}
+		})
+	}
+}
+
+func TestFlattenCfg(t *testing.T) {
+	got := flattenCfg("", map[string]any{"b": map[string]any{"y": "1", "x": []any{"p", "q"}}, "a": int64(2)})
+	want := [][2]string{{"a", "2"}, {"b.x", "p,q"}, {"b.y", "1"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("flattenCfg = %v, want %v", got, want)
 	}
 }

--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -38,7 +38,9 @@ func Command(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "produce [TOPIC]",
 		Short: "Produce records.",
-		Long: `Produce records, optionally to a specific topic, from stdin.
+		Long: `Produce records.
+
+Produce records, optionally to a specific topic, from stdin.
 
 By default, producing reads newline delimited, unkeyed records from stdin.
 The input format (-f) can be specified with delimiters or with sized numbers,
@@ -135,7 +137,7 @@ As well, these text options can be parsed with regular expressions:
   %k{re[\d*]}%v{re[\s+]}
 
 
-EXAMPLES
+EXAMPLES:
 
 To read a newline delimited file, each line a record (no keys):
   -f '%v\n'

--- a/commands/produce/produce.go
+++ b/commands/produce/produce.go
@@ -398,7 +398,7 @@ Examples:
 	cmd.Flags().BoolVar(&allowAutoTopicCreate, "allow-auto-topic-creation", false, "allow auto-creation of topics that don't exist")
 	cmd.Flags().StringArrayVarP(&headers, "header", "H", nil, "header in key=value format to attach to each record (repeatable)")
 
-	cmd.Flags().StringVar(&valueSchemaSpec, "schema", "", "Schema Registry encode the value; spec is topic[@ver] | subject[@ver] | subject:NAME[@ver] | id:N, with optional #message (see help)")
+	cmd.Flags().StringVarP(&valueSchemaSpec, "schema", "s", "", "Schema Registry encode the value; spec is topic[@ver] | subject[@ver] | subject:NAME[@ver] | id:N, with optional #message (see help)")
 	cmd.Flags().StringVar(&keySchemaSpec, "key-schema", "", "Schema Registry encode the key; same spec form as --schema")
 
 	return cmd

--- a/commands/registry/compat.go
+++ b/commands/registry/compat.go
@@ -85,7 +85,9 @@ func compatTestCommand(cl *client.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test SUBJECT",
 		Short: "Test whether a schema is compatible with a subject version.",
-		Long: `Test whether a candidate schema is compatible with an existing subject version.
+		Long: `Test whether a schema is compatible with a subject version.
+
+Test whether a candidate schema is compatible with an existing subject version.
 
 The candidate schema is read from -s/--schema or stdin. --version selects which
 existing version to check against ("latest" by default, or "all" to check

--- a/commands/registry/context.go
+++ b/commands/registry/context.go
@@ -14,7 +14,9 @@ func contextCommand(cl *client.Client) *cobra.Command {
 		Use:     "context",
 		Aliases: []string{"ctx"},
 		Short:   "List or delete schema registry contexts (namespaces).",
-		Long: `List or delete schema registry contexts.
+		Long: `List or delete schema registry contexts (namespaces).
+
+List or delete schema registry contexts.
 
 A context is an independent namespace within a registry: subjects and schema
 ids are unique per context. Scope any registry command to a context with the

--- a/commands/registry/references.go
+++ b/commands/registry/references.go
@@ -15,7 +15,9 @@ func referencesCommand(cl *client.Client) *cobra.Command {
 		Use:     "references SUBJECT",
 		Aliases: []string{"refs", "referenced-by"},
 		Short:   "List schemas that reference a subject version.",
-		Long: `List the schemas that reference a given subject version.
+		Long: `List schemas that reference a subject version.
+
+List the schemas that reference a given subject version.
 
 This is the reverse of a schema's own references: it answers "who depends on
 this schema?", which is useful before deleting or evolving it.`,

--- a/commands/registry/registry.go
+++ b/commands/registry/registry.go
@@ -31,7 +31,9 @@ func Command(cl *client.Client) *cobra.Command {
 		Use:     "registry",
 		Aliases: []string{"sr"},
 		Short:   "Schema Registry administration (schemas, subjects, compatibility, mode).",
-		Long: `Schema Registry administration.
+		Long: `Schema Registry administration (schemas, subjects, compatibility, mode).
+
+Schema Registry administration.
 
 The Schema Registry is a separate HTTP service from the Kafka brokers. Point
 kcl at it with any of:

--- a/commands/registry/schema.go
+++ b/commands/registry/schema.go
@@ -121,7 +121,9 @@ func schemaGetCommand(cl *client.Client) *cobra.Command {
 		Use:     "get",
 		Aliases: []string{"describe", "fetch"},
 		Short:   "Fetch a schema by id, or by subject and version.",
-		Long: `Fetch a schema by global id, or by subject and version.
+		Long: `Fetch a schema by id, or by subject and version.
+
+Fetch a schema by global id, or by subject and version.
 
 Exactly one of --id or --subject must be given. With --subject, --version
 defaults to "latest"; pass a specific version number to fetch an older one.
@@ -213,7 +215,9 @@ func schemaListCommand(cl *client.Client) *cobra.Command {
 		Use:     "list [SUBJECT]",
 		Aliases: []string{"ls"},
 		Short:   "List schemas across all subjects, or all versions of one subject.",
-		Long: `List registered schemas.
+		Long: `List schemas across all subjects, or all versions of one subject.
+
+List registered schemas.
 
 With no argument, lists every schema across all subjects. With a SUBJECT, lists
 that subject's schema versions. Each row shows the subject, version, id, and

--- a/main.go
+++ b/main.go
@@ -230,9 +230,19 @@ Command completion is available at:
 		os.Exit(0)
 	}
 
-	if err := root.Execute(); err != nil {
-		out.HandleError(asUsageError(err), cl.Format())
+	if cmd, err := root.ExecuteC(); err != nil {
+		out.HandleError(asUsageError(err), cl.Format(), commandName(cmd))
 	}
+}
+
+// commandName is the _command a document from cmd carries: the command path
+// under kcl with dots, "topic.list", or "" at the root.
+func commandName(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	path := strings.TrimSpace(strings.TrimPrefix(cmd.CommandPath(), "kcl"))
+	return strings.ReplaceAll(path, " ", ".")
 }
 
 // usageErrors wraps every command's argument validator and the flag error

--- a/main.go
+++ b/main.go
@@ -104,7 +104,8 @@ func isPseudoVersion(v string) bool {
 	return false
 }
 
-func main() {
+// buildRoot builds the whole command tree with the client it shares.
+func buildRoot() (*cobra.Command, *client.Client) {
 	v := resolveVersion()
 	client.SetVersion(v)
 	if version == "" && v == "dev" {
@@ -221,6 +222,12 @@ Command completion is available at:
 	root.RegisterFlagCompletionFunc("config-opt", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return client.XCompletions(), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	})
+
+	return root, cl
+}
+
+func main() {
+	root, cl := buildRoot()
 
 	if wantsHelpJSON(os.Args[1:]) {
 		tree := buildCommandJSON(root, false)

--- a/main_test.go
+++ b/main_test.go
@@ -181,3 +181,62 @@ func TestCommandName(t *testing.T) {
 		}
 	}
 }
+
+// TestTreeShorthandsAndUsage builds the whole tree, which panics on a
+// shorthand collision, and pins the letters and usage lines that were made
+// consistent across commands.
+func TestTreeShorthandsAndUsage(t *testing.T) {
+	root, _ := buildRoot()
+	byPath := map[string]*cobra.Command{}
+	allCommands(root, func(c *cobra.Command) { byPath[c.CommandPath()] = c })
+
+	want := map[string]map[string]string{
+		"kcl acl create":                {"dry-run": "d"},
+		"kcl acl delete":                {"dry-run": "d"},
+		"kcl cluster elect-leaders":     {"dry-run": "d"},
+		"kcl cluster features update":   {"dry-run": "d"},
+		"kcl group delete":              {"dry-run": "d", "regex": "r"},
+		"kcl group describe":            {"regex": "r"},
+		"kcl group seek":                {"dry-run": "d", "topic": "t"},
+		"kcl group offset-delete":       {"topic": "t"},
+		"kcl quota alter":               {"dry-run": "d"},
+		"kcl share-group delete":        {"dry-run": "d", "regex": "r"},
+		"kcl share-group describe":      {"regex": "r"},
+		"kcl share-group seek":          {"dry-run": "d", "topic": "t"},
+		"kcl share-group offset-delete": {"topic": "t"},
+		"kcl topic delete":              {"dry-run": "d", "regex": "r"},
+		"kcl topic list":                {"regex": "r"},
+		"kcl topic trim-prefix":         {"offset": "o", "partitions": "p"},
+		"kcl topic add-partitions":      {"num": "n", "assignment": "a"},
+		"kcl user alter":                {"set": "s"},
+		"kcl produce":                   {"schema": "s"},
+	}
+	for path, flags := range want {
+		cmd := byPath[path]
+		if cmd == nil {
+			t.Errorf("no command %q", path)
+			continue
+		}
+		for name, sh := range flags {
+			f := cmd.Flags().Lookup(name)
+			if f == nil || f.Shorthand != sh {
+				t.Errorf("%s --%s: shorthand = %v, want -%s", path, name, f, sh)
+			}
+		}
+	}
+	for path, old := range map[string]string{"kcl group seek": "topics", "kcl share-group seek": "topics", "kcl topic add-partitions": "topic"} {
+		if f := byPath[path].Flags().Lookup(old); f == nil || !f.Hidden {
+			t.Errorf("%s --%s should still exist, hidden", path, old)
+		}
+	}
+	for path, use := range map[string]string{
+		"kcl topic create":              "create TOPICS...",
+		"kcl misc list-offsets":         "list-offsets TOPICS...",
+		"kcl topic add-partitions":      "add-partitions TOPIC",
+		"kcl share-group offset-delete": "offset-delete GROUP",
+	} {
+		if got := byPath[path].Use; got != use {
+			t.Errorf("%s Use = %q, want %q", path, got, use)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -168,3 +168,16 @@ func TestXCompletionRegistered(t *testing.T) {
 		t.Errorf("completions = %v", got)
 	}
 }
+
+func TestCommandName(t *testing.T) {
+	root := &cobra.Command{Use: "kcl"}
+	topic := &cobra.Command{Use: "topic"}
+	list := &cobra.Command{Use: "list", Run: func(*cobra.Command, []string) {}}
+	topic.AddCommand(list)
+	root.AddCommand(topic)
+	for cmd, want := range map[*cobra.Command]string{root: "", topic: "topic", list: "topic.list", nil: ""} {
+		if got := commandName(cmd); got != want {
+			t.Errorf("commandName = %q, want %q", got, want)
+		}
+	}
+}

--- a/out/out.go
+++ b/out/out.go
@@ -50,11 +50,12 @@ func Errf(code int, format string, args ...any) error {
 var ErrSilent = &ExitCodeError{Code: ExitError, Err: errors.New("")}
 
 // HandleError formats an error for output and calls os.Exit. If format is
-// "json", the error is written as JSON to stdout. Otherwise it is written
-// as plain text to stderr. The exit code is extracted from ExitCodeError
-// if present, otherwise defaults to 1. ErrSilent exits non-zero without
-// printing anything.
-func HandleError(err error, format string) {
+// "json", the error is written as JSON to stdout, with _command and
+// _version as a success document has when command is not empty. Otherwise
+// it is written as plain text to stderr. The exit code is extracted from
+// ExitCodeError if present, otherwise defaults to 1. ErrSilent exits
+// non-zero without printing anything.
+func HandleError(err error, format, command string) {
 	code := ExitError
 	var ce *ExitCodeError
 	if errors.As(err, &ce) {
@@ -64,10 +65,15 @@ func HandleError(err error, format string) {
 		os.Exit(code)
 	}
 	if format == FormatJSON {
-		writeJSON(map[string]any{
+		doc := map[string]any{
 			"error": err.Error(),
 			"code":  code,
-		})
+		}
+		if command != "" {
+			doc["_command"] = command
+			doc["_version"] = 1
+		}
+		writeJSON(doc)
 	} else {
 		fmt.Fprintln(os.Stderr, err)
 	}


### PR DESCRIPTION
The four argument-shape proposals from the command walkthrough, on top of #70. When #70 merges this shrinks to its own four commits.

- **One letter per flag.** `--dry-run` is `-d`, `--regex` is `-r`, `--offset` and `--partitions` on `trim-prefix` are `-o` and `-p`, `--set` on `user alter` is `-s`, `--schema` on `produce` is `-s`, wherever the letter was free. Nothing removed or moved. A test builds the whole tree, which panics on any shorthand collision, and pins the letters.
- **`-t/--topic` on `group seek`, `share-group seek`, and `share-group offset-delete`**, matching `group offset-delete`, so the four read the same: one positional, the group, then flags. `--topics` and the positional topic list keep parsing, out of the help.
- **`topic add-partitions TOPIC`** with `-n COUNT`, `--total COUNT` (past it fails, at it exits 0 and does nothing, otherwise adds the difference), or `-a BROKERS` once per new partition in kcl's existing separators, commas between a partition's brokers, leader first, colons between partitions when given in one value. The old `-t foo 1,2 : 3,1` still parses when `-t` is present. Tested against kfake for every branch.
- **Usage strings.** `topic create TOPICS...`, `misc list-offsets TOPICS...`, and `config describe` now says which `-t` needs a name.

`elect-leaders`, `txn describe-producers`, `offset-for-leader-epoch`, `reassign alter`, and `logdirs alter` keep their positional lists; the list is the argument there.
