### PR TITLE
commands: take a topic id where a name is taken, and the subject as an argument

### DIFF
--- a/commands/admin/topic/describe.go
+++ b/commands/admin/topic/describe.go
@@ -73,7 +73,7 @@ SEE ALSO:
 			// Parse and validate topic IDs up front.
 			parsedIDs := make([][16]byte, 0, len(topicIDs))
 			for _, raw := range topicIDs {
-				id, err := parseTopicID(raw)
+				id, err := flagutil.ParseTopicID(raw)
 				if err != nil {
 					return out.Errf(out.ExitUsage, "invalid --topic-id %q: %v", raw, err)
 				}
@@ -519,22 +519,6 @@ SEE ALSO:
 	cmd.Flags().StringArrayVar(&topicIDs, "topic-id", nil, "topic UUID to describe (repeatable; 32 hex chars with optional dashes)")
 
 	return cmd
-}
-
-// parseTopicID accepts a topic UUID as either 32 hex chars or the
-// dashed 8-4-4-4-12 form and returns the raw 16 bytes.
-func parseTopicID(s string) ([16]byte, error) {
-	var id [16]byte
-	stripped := strings.ReplaceAll(s, "-", "")
-	if len(stripped) != 32 {
-		return id, fmt.Errorf("topic id must be 32 hex chars (with optional dashes), got %d", len(stripped))
-	}
-	raw, err := hex.DecodeString(stripped)
-	if err != nil {
-		return id, fmt.Errorf("not a hex string: %v", err)
-	}
-	copy(id[:], raw)
-	return id, nil
 }
 
 func fetchTopicConfigs(ctx context.Context, cl kmsg.Requestor, topics []string) (map[string][]kmsg.DescribeConfigsResponseResourceConfig, error) {

--- a/commands/admin/topic/describe.go
+++ b/commands/admin/topic/describe.go
@@ -15,6 +15,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 
 	"github.com/twmb/kcl/client"
+	"github.com/twmb/kcl/flagutil"
 	"github.com/twmb/kcl/out"
 )
 
@@ -43,8 +44,10 @@ AWK mode defaults to partitions. JSON always includes all sections.
 
 Health filters show only partitions matching the condition.
 
-Topics can be referenced by name (positional args) or UUID (--topic-id,
-repeatable). UUIDs are 32 hex characters with optional dashes.
+An argument is a topic name; one shaped like a topic id that names no topic is
+looked up as an id instead. A name wins over an id, so --topic-id is how to
+mean the id when a topic is named after one. Ids are 32 hex characters with
+optional dashes.
 
 EXAMPLES:
   kcl topic describe foo                         # all sections
@@ -62,6 +65,10 @@ SEE ALSO:
 		RunE: func(_ *cobra.Command, topics []string) error {
 			if len(topics) == 0 && len(topicIDs) == 0 {
 				return out.Errf(out.ExitUsage, "at least one topic name or --topic-id is required")
+			}
+			topics, err := flagutil.ResolveTopics(context.Background(), cl.Client(), topics)
+			if err != nil {
+				return err
 			}
 			// Parse and validate topic IDs up front.
 			parsedIDs := make([][16]byte, 0, len(topicIDs))

--- a/commands/admin/topic/describe_test.go
+++ b/commands/admin/topic/describe_test.go
@@ -2,7 +2,6 @@ package topic
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -10,40 +9,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
-
-func TestParseTopicID(t *testing.T) {
-	tests := []struct {
-		in  string
-		err bool
-	}{
-		{"00000000000000000000000000000000", false},
-		{"465a97c59919152e1827030ce374ec71", false},
-		{"465a97c5-9919-152e-1827-030ce374ec71", false},
-		{"465a97c5-9919152e-1827-030ce374ec71", false}, // dashes are stripped regardless of position
-		{"", true},
-		{"short", true},
-		{"465a97c59919152e1827030ce374ec7g", true}, // non-hex
-		{"465a97c59919152e1827030ce374ec", true},   // 30 chars
-	}
-	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
-			_, err := parseTopicID(tt.in)
-			if tt.err {
-				if err == nil {
-					t.Errorf("parseTopicID(%q) expected error", tt.in)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("parseTopicID(%q): %v", tt.in, err)
-			}
-			stripped := strings.ReplaceAll(tt.in, "-", "")
-			if len(stripped) != 32 {
-				t.Fatalf("test input not 32 hex chars after strip: %q", tt.in)
-			}
-		})
-	}
-}
 
 func TestTopicDescribeMetadata(t *testing.T) {
 	c, err := kfake.NewCluster()

--- a/commands/admin/topic/topic.go
+++ b/commands/admin/topic/topic.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/twmb/kcl/client"
 	"github.com/twmb/kcl/commands/metadata"
+	"github.com/twmb/kcl/flagutil"
 	"github.com/twmb/kcl/kv"
 	"github.com/twmb/kcl/out"
 )
@@ -249,6 +250,12 @@ pattern will be deleted. Use --dry-run to see which topics would be deleted
 without actually deleting them.
 `,
 		RunE: func(_ *cobra.Command, topics []string) error {
+			if !useRegex {
+				var err error
+				if topics, err = flagutil.ResolveTopics(context.Background(), cl.Client(), topics); err != nil {
+					return err
+				}
+			}
 			if useRegex {
 				if ids {
 					return out.Errf(out.ExitUsage, "--regex and --ids cannot be used together")
@@ -401,7 +408,10 @@ add-partitions foo -a 1,2 -a 3,1 -a 2,3  # three more, on brokers 1+2, 3+1, 2+3`
 				if len(args) != 1 {
 					return out.Errf(out.ExitUsage, "add-partitions takes one topic, then -n COUNT or -a BROKERS once per new partition")
 				}
-				topics = args
+				var err error
+				if topics, err = flagutil.ResolveTopics(context.Background(), cl.Client(), args); err != nil {
+					return err
+				}
 				switch {
 				case num > 0 && total > 0:
 					return out.Errf(out.ExitUsage, "-n and --total are exclusive")

--- a/commands/admin/topic/trim_prefix.go
+++ b/commands/admin/topic/trim_prefix.go
@@ -17,6 +17,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 
 	"github.com/twmb/kcl/client"
+	"github.com/twmb/kcl/flagutil"
 	"github.com/twmb/kcl/offsetparse"
 	"github.com/twmb/kcl/out"
 )
@@ -57,7 +58,11 @@ SEE ALSO:
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			topicName := args[0]
+			resolved, err := flagutil.ResolveTopics(context.Background(), cl.Client(), args)
+			if err != nil {
+				return err
+			}
+			topicName := resolved[0]
 
 			kclClient := cl.Client()
 			adm := kadm.NewClient(kclClient)

--- a/commands/registry/schema.go
+++ b/commands/registry/schema.go
@@ -118,28 +118,37 @@ func schemaGetCommand(cl *client.Client) *cobra.Command {
 		meta       bool
 	)
 	cmd := &cobra.Command{
-		Use:     "get",
+		Use:     "get [SUBJECT]",
 		Aliases: []string{"describe", "fetch"},
-		Short:   "Fetch a schema by id, or by subject and version.",
-		Long: `Fetch a schema by id, or by subject and version.
+		Short:   "Fetch a schema by subject and version, or by id.",
+		Long: `Fetch a schema by subject and version, or by id.
 
-Fetch a schema by global id, or by subject and version.
-
-Exactly one of --id or --subject must be given. With --subject, --version
-defaults to "latest"; pass a specific version number to fetch an older one.
+Give the subject, or --id for a global schema id. With a subject, --version
+defaults to "latest"; pass a version number to fetch an older one.
 
 By default only the schema text is printed (so it can be piped). Use --meta to
 also print the subject/version/id/type to stderr. In JSON output format the
 full structured schema (including references) is always printed.
 
+EXAMPLES:
+  kcl registry schema get mytopic-value
+  kcl registry schema get mytopic-value -v 2 --meta
   kcl registry schema get --id 5
-  kcl registry schema get -S mytopic-value
-  kcl registry schema get -S mytopic-value -v 2 --meta
+
+SEE ALSO:
+  kcl registry schema list   list schemas, by subject or across all
+  kcl registry versions      list the versions of a subject
 `,
-		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				if subject != "" {
+					return out.Errf(out.ExitUsage, "subject given both as an argument and with --subject")
+				}
+				subject = args[0]
+			}
 			if (id > 0) == (subject != "") {
-				return out.Errf(out.ExitUsage, "exactly one of --id or --subject must be specified")
+				return out.Errf(out.ExitUsage, "exactly one of a subject or --id must be given")
 			}
 
 			scl, err := srClient(cl)
@@ -203,8 +212,9 @@ full structured schema (including references) is always printed.
 		},
 	}
 	cmd.Flags().IntVarP(&id, "id", "i", 0, "global schema id to fetch")
-	cmd.Flags().StringVarP(&subject, "subject", "S", "", "subject to fetch a schema from")
-	cmd.Flags().StringVarP(&versionStr, "version", "v", "latest", "version to fetch with --subject (number or 'latest')")
+	cmd.Flags().StringVarP(&subject, "subject", "S", "", "old name for the subject argument")
+	cmd.Flags().MarkHidden("subject")
+	cmd.Flags().StringVarP(&versionStr, "version", "v", "latest", "version to fetch with a subject (number or 'latest')")
 	cmd.Flags().BoolVarP(&meta, "meta", "m", false, "print subject/version/id/type metadata to stderr in text mode")
 	return cmd
 }

--- a/commands/registry/schema_get_test.go
+++ b/commands/registry/schema_get_test.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/twmb/kcl/client"
+	"github.com/twmb/kcl/out"
+)
+
+// TestSchemaGetSubjectArg pins that the subject is an argument, that -S
+// still works, and that the combinations are refused.
+func TestSchemaGetSubjectArg(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "nothing", args: []string{}, wantErr: "exactly one of a subject or --id"},
+		{name: "argument and --subject", args: []string{"s", "-S", "s"}, wantErr: "both as an argument and with --subject"},
+		{name: "argument and --id", args: []string{"s", "--id", "1"}, wantErr: "exactly one of a subject or --id"},
+		{name: "two arguments", args: []string{"a", "b"}, wantErr: "accepts at most 1 arg"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := &cobra.Command{Use: "kcl", SilenceUsage: true, SilenceErrors: true}
+			cl := client.New(root)
+			root.AddCommand(Command(cl))
+			root.SetArgs(append([]string{"--no-config-file", "registry", "schema", "get"}, test.args...))
+			err := root.Execute()
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, test.wantErr)
+			}
+			var ce *out.ExitCodeError
+			if errors.As(err, &ce) && ce.Code != out.ExitUsage {
+				t.Errorf("exit code = %d, want %d", ce.Code, out.ExitUsage)
+			}
+		})
+	}
+
+	// The subject flag still resolves, but is out of the help.
+	root := &cobra.Command{Use: "kcl"}
+	cl := client.New(root)
+	root.AddCommand(Command(cl))
+	get, _, err := root.Find([]string{"registry", "schema", "get"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f := get.Flags().Lookup("subject"); f == nil || !f.Hidden {
+		t.Errorf("--subject should exist and be hidden, got %v", f)
+	}
+	if get.Use != "get [SUBJECT]" {
+		t.Errorf("Use = %q", get.Use)
+	}
+}

--- a/flagutil/topicid.go
+++ b/flagutil/topicid.go
@@ -1,0 +1,84 @@
+package flagutil
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// ParseTopicID accepts a topic UUID as either 32 hex chars or the dashed
+// 8-4-4-4-12 form and returns the raw 16 bytes.
+func ParseTopicID(s string) ([16]byte, error) {
+	var id [16]byte
+	stripped := strings.ReplaceAll(s, "-", "")
+	if len(stripped) != 32 {
+		return id, fmt.Errorf("topic id must be 32 hex chars (with optional dashes), got %d", len(stripped))
+	}
+	raw, err := hex.DecodeString(stripped)
+	if err != nil {
+		return id, fmt.Errorf("not a hex string: %v", err)
+	}
+	copy(id[:], raw)
+	return id, nil
+}
+
+// MaybeTopicID reports whether s could be a topic id. A topic name may look
+// exactly like one, since Kafka allows the same characters in a name.
+func MaybeTopicID(s string) bool {
+	_, err := ParseTopicID(s)
+	return err == nil
+}
+
+// ResolveTopics maps topic arguments to topic names. An argument is a name;
+// one shaped like a topic id that names no existing topic is looked up as an
+// id instead. A name always wins over an id, so a flag is the way to mean
+// the id when a topic is named after one.
+//
+// The cluster is only asked when an argument is shaped like an id, so the
+// ordinary case costs nothing.
+func ResolveTopics(ctx context.Context, cl kmsg.Requestor, args []string) ([]string, error) {
+	var ambiguous bool
+	for _, a := range args {
+		if MaybeTopicID(a) {
+			ambiguous = true
+			break
+		}
+	}
+	if !ambiguous {
+		return args, nil
+	}
+
+	req := kmsg.NewPtrMetadataRequest() // nil Topics: every topic
+	resp, err := req.RequestWith(ctx, cl)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list topics to resolve topic ids: %v", err)
+	}
+	names := make(map[string]bool, len(resp.Topics))
+	byID := make(map[[16]byte]string, len(resp.Topics))
+	for _, t := range resp.Topics {
+		if err := kerr.ErrorForCode(t.ErrorCode); err != nil || t.Topic == nil {
+			continue
+		}
+		names[*t.Topic] = true
+		byID[t.TopicID] = *t.Topic
+	}
+
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		if names[a] || !MaybeTopicID(a) {
+			out = append(out, a)
+			continue
+		}
+		id, _ := ParseTopicID(a)
+		name, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("no topic named %q, and no topic with that id", a)
+		}
+		out = append(out, name)
+	}
+	return out, nil
+}

--- a/flagutil/topicid.go
+++ b/flagutil/topicid.go
@@ -2,27 +2,21 @@ package flagutil
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
-	"strings"
+	"uuid"
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
-// ParseTopicID accepts a topic UUID as either 32 hex chars or the dashed
-// 8-4-4-4-12 form and returns the raw 16 bytes.
+// ParseTopicID returns the 16 bytes of a topic id, which may be written as
+// bare hex, the dashed 8-4-4-4-12 form, in either case, and with a urn:uuid:
+// prefix or braces around it.
 func ParseTopicID(s string) ([16]byte, error) {
-	var id [16]byte
-	stripped := strings.ReplaceAll(s, "-", "")
-	if len(stripped) != 32 {
-		return id, fmt.Errorf("topic id must be 32 hex chars (with optional dashes), got %d", len(stripped))
-	}
-	raw, err := hex.DecodeString(stripped)
+	id, err := uuid.Parse(s)
 	if err != nil {
-		return id, fmt.Errorf("not a hex string: %v", err)
+		return [16]byte{}, fmt.Errorf("not a topic id: %v", err)
 	}
-	copy(id[:], raw)
 	return id, nil
 }
 

--- a/flagutil/topicid_test.go
+++ b/flagutil/topicid_test.go
@@ -1,0 +1,125 @@
+package flagutil
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestParseTopicIDAndMaybe(t *testing.T) {
+	for _, test := range []struct {
+		in    string
+		ok    bool
+		first byte
+	}{
+		{in: "15fc1bf40a5c1c3cdd363ec28f5c0c69", ok: true, first: 0x15},
+		{in: "15fc1bf4-0a5c-1c3c-dd36-3ec28f5c0c69", ok: true, first: 0x15},
+		{in: "mytopic"},
+		{in: ""},
+		{in: "15fc1bf40a5c1c3cdd363ec28f5c0c6"},   // 31
+		{in: "15fc1bf40a5c1c3cdd363ec28f5c0c699"}, // 33
+		{in: "zzfc1bf40a5c1c3cdd363ec28f5c0c69"},  // not hex
+	} {
+		t.Run(test.in, func(t *testing.T) {
+			id, err := ParseTopicID(test.in)
+			if (err == nil) != test.ok {
+				t.Fatalf("err = %v, want ok %v", err, test.ok)
+			}
+			if got := MaybeTopicID(test.in); got != test.ok {
+				t.Errorf("MaybeTopicID = %v, want %v", got, test.ok)
+			}
+			if test.ok && id[0] != test.first {
+				t.Errorf("id[0] = %#x, want %#x", id[0], test.first)
+			}
+		})
+	}
+}
+
+// TestResolveTopics pins that a name beats an id, an id resolves to its
+// name, and an argument that is neither is reported.
+func TestResolveTopics(t *testing.T) {
+	c, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, "plain"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	cl, err := kgo.NewClient(kgo.SeedBrokers(c.ListenAddrs()...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// The id of "plain", and a topic named after that id.
+	req := kmsg.NewPtrMetadataRequest()
+	resp, err := req.RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var plainID string
+	for _, tp := range resp.Topics {
+		if tp.Topic != nil && *tp.Topic == "plain" {
+			plainID = hexID(tp.TopicID)
+		}
+	}
+	if plainID == "" {
+		t.Fatal("no id for the seeded topic")
+	}
+
+	create := kmsg.NewPtrCreateTopicsRequest()
+	for _, name := range []string{plainID, "0123456789abcdef0123456789abcdef"} {
+		ct := kmsg.NewCreateTopicsRequestTopic()
+		ct.Topic = name
+		ct.NumPartitions = 1
+		ct.ReplicationFactor = 1
+		create.Topics = append(create.Topics, ct)
+	}
+	if _, err := create.RequestWith(ctx, cl); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name    string
+		args    []string
+		want    []string
+		wantErr string
+	}{
+		{name: "plain names are untouched", args: []string{"plain", "other"}, want: []string{"plain", "other"}},
+		{name: "an id resolves to its name", args: []string{"0123456789abcdef0123456789abcdef"}, want: []string{"0123456789abcdef0123456789abcdef"}},
+		{name: "a name that looks like an id wins", args: []string{plainID}, want: []string{plainID}},
+		{name: "mixed", args: []string{"plain", plainID}, want: []string{"plain", plainID}},
+		{name: "neither", args: []string{"ffffffffffffffffffffffffffffffff"}, wantErr: "no topic named"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ResolveTopics(ctx, cl, test.args)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func hexID(id [16]byte) string {
+	const hexc = "0123456789abcdef"
+	b := make([]byte, 0, 32)
+	for _, c := range id {
+		b = append(b, hexc[c>>4], hexc[c&0xf])
+	}
+	return string(b)
+}

--- a/flagutil/topicid_test.go
+++ b/flagutil/topicid_test.go
@@ -20,6 +20,11 @@ func TestParseTopicIDAndMaybe(t *testing.T) {
 	}{
 		{in: "15fc1bf40a5c1c3cdd363ec28f5c0c69", ok: true, first: 0x15},
 		{in: "15fc1bf4-0a5c-1c3c-dd36-3ec28f5c0c69", ok: true, first: 0x15},
+		{in: "15FC1BF40A5C1C3CDD363EC28F5C0C69", ok: true, first: 0x15},
+		{in: "15FC1BF4-0A5C-1C3C-DD36-3EC28F5C0C69", ok: true, first: 0x15},
+		{in: "urn:uuid:15fc1bf4-0a5c-1c3c-dd36-3ec28f5c0c69", ok: true, first: 0x15},
+		{in: "{15fc1bf4-0a5c-1c3c-dd36-3ec28f5c0c69}", ok: true, first: 0x15},
+		{in: "00000000-0000-0000-0000-000000000000", ok: true},
 		{in: "mytopic"},
 		{in: ""},
 		{in: "15fc1bf40a5c1c3cdd363ec28f5c0c6"},   // 31

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/kcl
 
-go 1.26.0
+go 1.27
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
Identifiers that a command already understands are now accepted as its argument.

**Topic ids, wherever a topic name is taken.** Only `topic describe` accepted an id, and only through `--topic-id`. An argument to `describe`, `delete`, `add-partitions`, or `trim-prefix` is now a name; one shaped like an id that names no topic is looked up as an id instead.

```
kcl topic describe 20c5261718ac53c6f35efeb8e6608009   # by id
kcl topic delete 2adcfdd69dc1631a70bed8a08adad380     # by id
kcl topic add-partitions <id> -n 1
kcl topic trim-prefix <id> -o 0
```

A name wins over an id, since Kafka lets a topic be named 32 hex characters, so `--topic-id` is how to mean the id when a topic is named after one. Verified against a cluster holding a topic named after another topic's id: the argument resolved to the name, `--topic-id` to the other topic.

The cluster is only asked to resolve when an argument is shaped like an id, so the ordinary case costs no extra request. An argument that is neither says so: `no topic named "ffff...", and no topic with that id`.

**`registry schema get` takes the subject as its argument.** It was the only command in the registry group taking the subject through a flag, so `kcl registry schema get mytopic-value` answered with cobra's `unknown command "mytopic-value"`. Its eleven siblings all take the subject positionally. `--subject` keeps working, out of the help.

The two modes did not force a flag: the argument is optional and `--id` is the other way to name a schema, which is the shape `topic describe` already uses for `--topic-id`.

```
kcl registry schema get mytopic-value
kcl registry schema get mytopic-value -v 2 --meta
kcl registry schema get --id 5
```

Combining an argument with `--subject` or `--id` is a usage error.

**Where else this applies.** I checked every request in kmsg for a topic id alongside a name, and every id-style flag in the tree. `DeleteTopics` and `Metadata` carry an id natively; the rest of the topic surface (`CreatePartitions`, `DeleteRecords`, `DescribeConfigs`, log dirs, reassignments, list-offsets) is name-only, which the resolver handles by mapping the id to its name first. Nothing else in the tree has two identifiers for one thing: groups, transactional ids, client-metrics names, and quota entities have only a name, and brokers only an id.

Tests: the resolver against kfake including the ambiguous case, the parser as a table, and the registry argument combinations through cobra.
